### PR TITLE
ci(repo): fix label sync workflow checkout

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,6 +10,8 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Sync GitHub labels
         uses: crazy-max/ghaction-github-labeler@v5
         with:


### PR DESCRIPTION
## Summary
- check out the repo before syncing labels so .github/labels.yml is available

## Testing
- not run (workflow config)