### PR TITLE
refactor(repo): extract shared UI logic into zann-ui-core

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,11 @@
 use flake
 
+# Стабильный путь к тулчейну для IDE. В RustRover в "Rust → Toolchain
+# location" указывается .direnv/toolchain — и настройка переживает
+# обновления flake.lock, потому что симлинк обновляет direnv.
+mkdir -p .direnv
+ln -sfn "$(dirname "$(command -v rustc)")" .direnv/toolchain
+
 ZANN_DESKTOP_DIR="$PWD/apps/desktop"
 PATH_add "$ZANN_DESKTOP_DIR/node_modules/.bin"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4038,7 +4044,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5133,6 +5139,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "totp-rs"
+version = "5.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e69a15e21b2ff22c415446983978bded3244195f17d59cb113551c1e806f91"
+dependencies = [
+ "base32",
+ "constant_time_eq",
+ "hmac",
+ "sha1",
+ "sha2",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5780,7 +5799,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6287,6 +6306,7 @@ dependencies = [
  "zann-core",
  "zann-crypto",
  "zann-db",
+ "zann-ui-core",
 ]
 
 [[package]]
@@ -6349,6 +6369,17 @@ dependencies = [
  "zann-core",
  "zann-crypto",
  "zann-db",
+]
+
+[[package]]
+name = "zann-ui-core"
+version = "0.1.0"
+dependencies = [
+ "data-encoding",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "totp-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/zann-keystore",
   "crates/zann-server",
   "crates/zann-cli",
+  "crates/zann-ui-core",
 ]
 exclude = [
   "apps/desktop/src-tauri",

--- a/apps/desktop/bun.lock
+++ b/apps/desktop/bun.lock
@@ -20,8 +20,8 @@
         "vue-i18n": "^9.13.1",
       },
       "devDependencies": {
-        "@tauri-apps/api": "^2.11.0",
-        "@tauri-apps/cli": "^2.11.2",
+        "@tauri-apps/api": "^2.11.1",
+        "@tauri-apps/cli": "^2.11.4",
         "@testing-library/vue": "^8.1.0",
         "@vitejs/plugin-vue": "^5.0.0",
         "autoprefixer": "^10.4.20",
@@ -194,31 +194,31 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.54.0", "", { "os": "win32", "cpu": "x64" }, "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg=="],
 
-    "@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.1", "", {}, "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA=="],
 
-    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.2", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.2", "@tauri-apps/cli-darwin-x64": "2.11.2", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2", "@tauri-apps/cli-linux-arm64-gnu": "2.11.2", "@tauri-apps/cli-linux-arm64-musl": "2.11.2", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2", "@tauri-apps/cli-linux-x64-gnu": "2.11.2", "@tauri-apps/cli-linux-x64-musl": "2.11.2", "@tauri-apps/cli-win32-arm64-msvc": "2.11.2", "@tauri-apps/cli-win32-ia32-msvc": "2.11.2", "@tauri-apps/cli-win32-x64-msvc": "2.11.2" }, "bin": { "tauri": "tauri.js" } }, "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw=="],
+    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.4", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.4", "@tauri-apps/cli-darwin-x64": "2.11.4", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4", "@tauri-apps/cli-linux-arm64-gnu": "2.11.4", "@tauri-apps/cli-linux-arm64-musl": "2.11.4", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.4", "@tauri-apps/cli-linux-x64-gnu": "2.11.4", "@tauri-apps/cli-linux-x64-musl": "2.11.4", "@tauri-apps/cli-win32-arm64-msvc": "2.11.4", "@tauri-apps/cli-win32-ia32-msvc": "2.11.4", "@tauri-apps/cli-win32-x64-msvc": "2.11.4" }, "bin": { "tauri": "tauri.js" } }, "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ=="],
 
-    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w=="],
+    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ=="],
 
-    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg=="],
+    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A=="],
 
-    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.2", "", { "os": "linux", "cpu": "arm" }, "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA=="],
+    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.4", "", { "os": "linux", "cpu": "arm" }, "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ=="],
 
-    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw=="],
+    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA=="],
 
-    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw=="],
+    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw=="],
 
-    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.2", "", { "os": "linux", "cpu": "riscv64" }, "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ=="],
+    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.4", "", { "os": "linux", "cpu": "none" }, "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ=="],
 
-    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw=="],
+    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.4", "", { "os": "linux", "cpu": "x64" }, "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ=="],
 
-    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw=="],
+    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.4", "", { "os": "linux", "cpu": "x64" }, "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A=="],
 
-    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA=="],
+    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ=="],
 
-    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA=="],
+    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA=="],
 
-    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.2", "", { "os": "win32", "cpu": "x64" }, "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA=="],
+    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw=="],
 
     "@tauri-apps/plugin-clipboard-manager": ["@tauri-apps/plugin-clipboard-manager@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ=="],
 
@@ -1070,6 +1070,10 @@
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
+    "@tauri-apps/plugin-clipboard-manager/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/plugin-shell/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.1.3", "", { "dependencies": { "deep-equal": "^2.0.5" } }, "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ=="],
 
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
@@ -1125,6 +1129,8 @@
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "tauri-plugin-biometry-api/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 

--- a/apps/desktop/bun.lock
+++ b/apps/desktop/bun.lock
@@ -31,6 +31,7 @@
         "typescript": "^5.6.0",
         "vite": "^5.4.0",
         "vitest": "^2.1.4",
+        "vue-tsc": "^3.3.9",
         "webdriverio": "^9.0.0",
       },
     },
@@ -260,6 +261,12 @@
 
     "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
 
+    "@volar/language-core": ["@volar/language-core@2.4.28", "", { "dependencies": { "@volar/source-map": "2.4.28" } }, "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ=="],
+
+    "@volar/source-map": ["@volar/source-map@2.4.28", "", {}, "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ=="],
+
+    "@volar/typescript": ["@volar/typescript@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "path-browserify": "^1.0.1", "vscode-uri": "^3.0.8" } }, "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw=="],
+
     "@vue/compiler-core": ["@vue/compiler-core@3.5.26", "", { "dependencies": { "@babel/parser": "^7.28.5", "@vue/shared": "3.5.26", "entities": "^7.0.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w=="],
 
     "@vue/compiler-dom": ["@vue/compiler-dom@3.5.26", "", { "dependencies": { "@vue/compiler-core": "3.5.26", "@vue/shared": "3.5.26" } }, "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A=="],
@@ -269,6 +276,8 @@
     "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.26", "", { "dependencies": { "@vue/compiler-dom": "3.5.26", "@vue/shared": "3.5.26" } }, "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw=="],
 
     "@vue/devtools-api": ["@vue/devtools-api@6.6.4", "", {}, "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="],
+
+    "@vue/language-core": ["@vue/language-core@3.3.9", "", { "dependencies": { "@volar/language-core": "2.4.28", "@vue/compiler-dom": "^3.5.0", "@vue/shared": "^3.5.0", "alien-signals": "^3.2.1", "muggle-string": "^0.4.1", "path-browserify": "^1.0.1", "picomatch": "^4.0.4" } }, "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ=="],
 
     "@vue/reactivity": ["@vue/reactivity@3.5.26", "", { "dependencies": { "@vue/shared": "3.5.26" } }, "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ=="],
 
@@ -301,6 +310,8 @@
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "alien-signals": ["alien-signals@3.2.1", "", {}, "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -732,6 +743,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
+
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -775,6 +788,8 @@
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
 
     "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1014,11 +1029,15 @@
 
     "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
     "vue": ["vue@3.5.26", "", { "dependencies": { "@vue/compiler-dom": "3.5.26", "@vue/compiler-sfc": "3.5.26", "@vue/runtime-dom": "3.5.26", "@vue/server-renderer": "3.5.26", "@vue/shared": "3.5.26" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA=="],
 
     "vue-component-type-helpers": ["vue-component-type-helpers@2.2.12", "", {}, "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw=="],
 
     "vue-i18n": ["vue-i18n@9.14.5", "", { "dependencies": { "@intlify/core-base": "9.14.5", "@intlify/shared": "9.14.5", "@vue/devtools-api": "^6.5.0" }, "peerDependencies": { "vue": "^3.0.0" } }, "sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g=="],
+
+    "vue-tsc": ["vue-tsc@3.3.9", "", { "dependencies": { "@volar/typescript": "2.4.28", "@vue/language-core": "3.3.9" }, "peerDependencies": { "typescript": ">=5.0.0" }, "bin": { "vue-tsc": "bin/vue-tsc.js" } }, "sha512-TS3Y1ux/IRoE8OCP2PpACAeOseuIs0UvWrcr7u+w3PmfY+SlCfEf8zjrBgnQksHUgLpthi5vHlffcQTQTdPBZA=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
@@ -1079,6 +1098,8 @@
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "@vue/compiler-core/entities": ["entities@7.0.0", "", {}, "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ=="],
+
+    "@vue/language-core/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "@wdio/logger/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,8 +28,8 @@
     "vue-i18n": "^9.13.1"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2.11.2",
-    "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/cli": "^2.11.4",
+    "@tauri-apps/api": "^2.11.1",
     "@vitejs/plugin-vue": "^5.0.0",
     "autoprefixer": "^10.4.20",
     "@testing-library/vue": "^8.1.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "e2e": "node ./scripts/e2e/run.mjs",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.1.0",
@@ -28,17 +29,18 @@
     "vue-i18n": "^9.13.1"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2.11.4",
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/cli": "^2.11.4",
+    "@testing-library/vue": "^8.1.0",
     "@vitejs/plugin-vue": "^5.0.0",
     "autoprefixer": "^10.4.20",
-    "@testing-library/vue": "^8.1.0",
     "jsdom": "^24.1.1",
     "postcss": "^8.4.45",
     "tailwindcss": "^3.4.13",
     "typescript": "^5.6.0",
     "vite": "^5.4.0",
     "vitest": "^2.1.4",
+    "vue-tsc": "^3.3.9",
     "webdriverio": "^9.0.0"
   }
 }

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1480,7 +1480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3515,7 +3515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4087,7 +4087,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4459,7 +4459,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4472,7 +4472,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5404,9 +5404,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.2"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5455,9 +5455,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
+checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -5476,9 +5476,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -5503,9 +5503,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5614,9 +5614,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.2"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -5639,9 +5639,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.2"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
@@ -5665,9 +5665,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
@@ -5724,7 +5724,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6121,9 +6121,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.23.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -6697,7 +6697,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7443,12 +7443,12 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tokio",
- "totp-rs",
  "url",
  "uuid",
  "zann-core",
  "zann-db",
  "zann-keystore",
+ "zann-ui-core",
 ]
 
 [[package]]
@@ -7460,6 +7460,17 @@ dependencies = [
  "keyring",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "zann-ui-core"
+version = "0.1.0"
+dependencies = [
+ "data-encoding",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "totp-rs",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -33,8 +33,8 @@ csv = "1"
 url = "2"
 percent-encoding = "2"
 tokio = { version = "1", features = ["rt", "sync"] }
-totp-rs = { version = "5.5", default-features = false }
 
 zann-core = { path = "../../../crates/zann-core", default-features = false, features = ["sqlite"] }
 zann-db = { path = "../../../crates/zann-db", default-features = false, features = ["sqlite"] }
 zann-keystore = { path = "../../../crates/zann-keystore" }
+zann-ui-core = { path = "../../../crates/zann-ui-core" }

--- a/apps/desktop/src-tauri/src/services/totp.rs
+++ b/apps/desktop/src-tauri/src/services/totp.rs
@@ -1,78 +1,14 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use data_encoding::BASE32;
-use totp_rs::{Algorithm, TOTP};
-
 use crate::types::TotpCodeResponse;
 
-#[derive(Debug)]
-pub struct TotpParams {
-    pub secret: String,
-    pub algorithm: Option<String>,
-    pub digits: Option<u32>,
-    pub period: Option<u32>,
-}
-
-fn parse_algorithm(value: Option<&str>) -> Result<Algorithm, String> {
-    let normalized = value.unwrap_or("SHA1").trim().to_uppercase();
-    match normalized.as_str() {
-        "SHA1" => Ok(Algorithm::SHA1),
-        "SHA256" => Ok(Algorithm::SHA256),
-        "SHA512" => Ok(Algorithm::SHA512),
-        _ => Err("unsupported otp algorithm".to_string()),
-    }
-}
-
-fn parse_digits(value: Option<u32>) -> Result<u32, String> {
-    let digits = value.unwrap_or(6);
-    match digits {
-        6 | 8 => Ok(digits),
-        _ => Err("unsupported otp digits".to_string()),
-    }
-}
-
-fn parse_period(value: Option<u32>) -> Result<u32, String> {
-    let period = value.unwrap_or(30);
-    if period == 0 {
-        return Err("invalid otp period".to_string());
-    }
-    Ok(period)
-}
-
-fn decode_secret(secret: &str) -> Result<Vec<u8>, String> {
-    let cleaned: String = secret
-        .chars()
-        .filter(|ch| !ch.is_whitespace() && *ch != '-')
-        .collect::<String>()
-        .to_uppercase();
-    BASE32
-        .decode(cleaned.as_bytes())
-        .map_err(|_| "invalid otp secret".to_string())
-}
+/// Re-exported so command handlers keep their existing import path.
+pub use zann_ui_core::TotpParams;
 
 pub fn generate_totp(params: TotpParams) -> Result<TotpCodeResponse, String> {
-    let algorithm = parse_algorithm(params.algorithm.as_deref())?;
-    let digits = parse_digits(params.digits)?;
-    let period = parse_period(params.period)?;
-    let secret_bytes = decode_secret(params.secret.trim())?;
-    let totp = TOTP::new(
-        algorithm,
-        digits as usize,
-        1,
-        period as u64,
-        secret_bytes,
-    )
-    .map_err(|err| err.to_string())?;
-    let code = totp.generate_current().map_err(|err| err.to_string())?;
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|_| "invalid system time".to_string())?
-        .as_secs();
-    let remaining = period as u64 - (now % period as u64);
+    let code = zann_ui_core::generate_totp(&params).map_err(|err| err.to_string())?;
     Ok(TotpCodeResponse {
-        code,
-        remaining_seconds: remaining as u32,
-        period,
+        code: code.code,
+        remaining_seconds: code.remaining_seconds,
+        period: code.period,
     })
 }
 

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -464,6 +464,24 @@ pub struct ItemSummary {
     pub deleted_at: Option<String>,
 }
 
+impl zann_ui_core::ItemLike for ItemSummary {
+    fn title(&self) -> &str {
+        &self.name
+    }
+
+    fn type_id(&self) -> &str {
+        &self.type_id
+    }
+
+    fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn is_deleted(&self) -> bool {
+        self.deleted_at.is_some()
+    }
+}
+
 #[derive(Serialize)]
 pub struct ItemDetail {
     pub id: String,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
     "windows": [
       {
         "title": "Zann Desktop",
-        "width": 1000,
+        "width": 1200,
         "height": 700,
         "minWidth": 1125,
         "minHeight": 650,

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -9,7 +9,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "lib": ["ES2020", "DOM"]
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM"],
+    "types": ["vite/client"]
   },
   "include": ["src/**/*.ts", "src/**/*.vue"]
 }

--- a/apps/kde/Cargo.lock
+++ b/apps/kde/Cargo.lock
@@ -3403,18 +3403,17 @@ dependencies = [
  "cxx-qt",
  "cxx-qt-build",
  "cxx-qt-lib",
- "data-encoding",
  "dirs",
  "qt-build-utils",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
- "totp-rs",
  "zann-client",
  "zann-core",
  "zann-db",
  "zann-ffi",
+ "zann-ui-core",
 ]
 
 [[package]]
@@ -3511,6 +3510,18 @@ dependencies = [
  "zann-core",
  "zann-crypto",
  "zann-db",
+ "zann-ui-core",
+]
+
+[[package]]
+name = "zann-ui-core"
+version = "0.1.0"
+dependencies = [
+ "data-encoding",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "totp-rs",
 ]
 
 [[package]]

--- a/apps/kde/Cargo.toml
+++ b/apps/kde/Cargo.toml
@@ -21,10 +21,9 @@ zann-client = { path = "../../crates/zann-client" }
 zann-db = { path = "../../crates/zann-db", features = ["sqlite"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 zann-core = { path = "../../crates/zann-core" }
+zann-ui-core = { path = "../../crates/zann-ui-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-totp-rs = "5"
-data-encoding = "2"
 reqwest = { version = "0.12", features = ["rustls-tls"] }
 dirs = "5"
 

--- a/apps/kde/qml/main.qml
+++ b/apps/kde/qml/main.qml
@@ -361,7 +361,7 @@ K.ApplicationWindow {
 
             // Progress arc
             if (otpRow.totpResult) {
-              var progress = otpRow.totpResult.remaining / otpRow.totpResult.period
+              var progress = otpRow.totpResult.remaining_seconds / otpRow.totpResult.period
               var startAngle = -Math.PI / 2
               var endAngle = startAngle + (2 * Math.PI * progress)
 
@@ -376,10 +376,10 @@ K.ApplicationWindow {
 
         Label {
           anchors.centerIn: parent
-          text: otpRow.totpResult ? otpRow.totpResult.remaining : ""
+          text: otpRow.totpResult ? otpRow.totpResult.remaining_seconds : ""
           font.pointSize: 9
           font.bold: true
-          color: otpRow.totpResult && otpRow.totpResult.remaining <= 5 ? K.Theme.negativeTextColor : K.Theme.textColor
+          color: otpRow.totpResult && otpRow.totpResult.remaining_seconds <= 5 ? K.Theme.negativeTextColor : K.Theme.textColor
         }
       }
 

--- a/apps/kde/src/cxxqt.rs
+++ b/apps/kde/src/cxxqt.rs
@@ -1,49 +1,20 @@
 use cxx_qt::CxxQtType;
 use cxx_qt_lib::{QString, QStringList};
-use data_encoding::BASE32;
-use serde::Deserialize;
 use std::sync::{mpsc, Arc};
-use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
-use totp_rs::{Algorithm, TOTP};
 use tokio::runtime::Runtime;
 use zann_client::types::OidcLoginStatusResponse;
 use zann_db::{connect_sqlite_with_max, migrate_local};
 use zann_core::AuthMethod;
 use zann_ffi::{create_core, CoreFacade, CoreResult, ItemCountsFfi, ItemsFilter, Page};
+use zann_ui_core::{
+    build_folder_tree, category_views, filtered_indices, normalize_server_url, FolderFilter,
+    ItemCounts, ItemFilter, TotpParams, VaultScope,
+};
 
-/// Embed the UI categories schema at compile time
-const UI_CATEGORIES_SCHEMA: &str = include_str!("../../../schemas/ui_categories.json");
 const LOCAL_DB_FILENAME: &str = "local.sqlite";
-
-/// Schema parsing structures
-#[derive(Clone, Deserialize)]
-struct UiCategoriesSchema {
-    categories: Vec<CategoryDef>,
-    #[allow(dead_code)]
-    fallback_category_id: String,
-}
-
-#[derive(Clone, Deserialize)]
-struct CategoryDef {
-    id: String,
-    labels: Vec<LabelDef>,
-    icon: String,
-    order: i32,
-    filter: Option<CategoryFilter>,
-}
-
-#[derive(Clone, Deserialize)]
-struct LabelDef {
-    key: String,
-}
-
-#[derive(Clone, Deserialize)]
-struct CategoryFilter {
-    type_ids: Option<Vec<String>>,
-    #[allow(dead_code)]
-    is_deleted: Option<bool>,
-}
+/// Sentinel QML uses for "items that are not in any folder"
+const NO_FOLDER_SENTINEL: &str = "__no_folder__";
 
 /// Map schema icon names to Kirigami icon names
 fn map_icon_to_kirigami(schema_icon: &str) -> &'static str {
@@ -72,6 +43,7 @@ fn translate_label_key(key: &str) -> &'static str {
         "nav.kv" => "Key/Value",
         "nav.infrastructure" => "Infrastructure",
         "nav.trash" => "Trash",
+        "items.trashShared" => "Shared trash",
         _ => "Unknown",
     }
 }
@@ -798,8 +770,14 @@ impl ffi::AppModel {
         digits: i32,
         period: i32,
     ) -> QString {
-        match generate_totp_internal(&secret.to_string(), &algorithm.to_string(), digits, period) {
-            Ok(response) => QString::from(response),
+        let params = TotpParams {
+            secret: secret.to_string(),
+            algorithm: Some(algorithm.to_string()),
+            digits: (digits > 0).then(|| digits as u32),
+            period: (period > 0).then(|| period as u32),
+        };
+        match zann_ui_core::generate_totp(&params) {
+            Ok(code) => QString::from(serde_json::to_string(&code).unwrap_or_default()),
             Err(_) => QString::from(""),
         }
     }
@@ -1794,17 +1772,6 @@ fn reload_core_from_config(rust: &mut AppModelRust) {
     }
 }
 
-fn normalize_server_url(value: &str) -> String {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return String::new();
-    }
-    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
-        return trimmed.to_string();
-    }
-    format!("https://{}", trimmed)
-}
-
 fn build_storages_list(storages: &[StorageRow]) -> QStringList {
     let mut list = QStringList::default();
     for storage in storages {
@@ -1938,333 +1905,42 @@ fn serialize_item_detail(item: &zann_ffi::ItemDetail) -> String {
     .unwrap_or_else(|_| "{}".to_string())
 }
 
+/// Render the shared category views for QML: i18n keys become English strings
+/// and schema icon names become Kirigami ones.
 fn serialize_categories(counts: &ItemCountsFfi) -> String {
-    let schema: UiCategoriesSchema = match serde_json::from_str(UI_CATEGORIES_SCHEMA) {
-        Ok(schema) => schema,
-        Err(_) => return "[]".to_string(),
-    };
-
-    // Build a lookup map for type_id -> count
-    let type_counts: std::collections::HashMap<&str, u64> = counts
-        .by_type
-        .iter()
-        .map(|entry| (entry.type_id.as_str(), entry.count))
-        .collect();
-
-    let mut categories: Vec<_> = schema
-        .categories
-        .iter()
-        .map(|cat| {
-            // Compute count based on filter
-            let count = match &cat.filter {
-                None => {
-                    // Special case for trash (no filter in schema means use trash count)
-                    if cat.id == "trash" {
-                        counts.trash
-                    } else {
-                        0
-                    }
-                }
-                Some(filter) => {
-                    match &filter.type_ids {
-                        None => {
-                            // No type_ids filter means "all" category
-                            counts.all
-                        }
-                        Some(type_ids) => {
-                            // Sum counts for all type_ids in the filter
-                            type_ids
-                                .iter()
-                                .map(|tid| type_counts.get(tid.as_str()).copied().unwrap_or(0u64))
-                                .sum::<u64>()
-                        }
-                    }
-                }
-            };
-
-            // Get label from first label entry
-            let label = cat
-                .labels
-                .first()
-                .map(|l| translate_label_key(&l.key))
-                .unwrap_or("Unknown");
-
-            // Map icon to Kirigami
-            let icon = map_icon_to_kirigami(&cat.icon);
-
-            // Build filter for QML
-            let filter_json = cat.filter.as_ref().map(|f| {
-                serde_json::json!({
-                    "type_ids": f.type_ids,
-                    "is_deleted": f.is_deleted,
-                })
-            });
-
-            (
-                cat.order,
-                serde_json::json!({
-                    "id": cat.id,
-                    "label": label,
-                    "icon": icon,
-                    "order": cat.order,
-                    "count": count,
-                    "filter": filter_json,
-                }),
-            )
+    let counts = ItemCounts::from(counts);
+    let categories: Vec<_> = category_views(&counts, VaultScope::Personal)
+        .into_iter()
+        .map(|view| {
+            serde_json::json!({
+                "id": view.id,
+                "label": translate_label_key(&view.label_key),
+                "icon": map_icon_to_kirigami(&view.icon),
+                "order": view.order,
+                "count": view.count,
+            })
         })
         .collect();
-
-    // Sort by order
-    categories.sort_by_key(|(order, _)| *order);
-
-    let result: Vec<_> = categories.into_iter().map(|(_, json)| json).collect();
-    serde_json::to_string(&result).unwrap_or_else(|_| "[]".to_string())
+    serde_json::to_string(&categories).unwrap_or_else(|_| "[]".to_string())
 }
 
 fn serialize_folders(items: &[zann_ffi::ItemSummary]) -> String {
-    use std::collections::{BTreeSet, HashMap};
-
-    #[derive(Default)]
-    struct FolderNode {
-        name: String,
-        path: String,
-        item_count: usize,
-        total_count: usize,
-        children: BTreeSet<String>,
-    }
-
-    let mut folder_paths = BTreeSet::<String>::new();
-    let mut item_counts = HashMap::<String, usize>::new();
-    let mut items_without_folder = 0usize;
-
-    for item in items {
-        let path = item.path.trim();
-        if path.is_empty() {
-            continue;
-        }
-        let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
-        if segments.len() < 2 {
-            items_without_folder += 1;
-            continue;
-        }
-
-        let folder_segments = &segments[..segments.len().saturating_sub(1)];
-        let mut current = String::new();
-        for segment in folder_segments {
-            if !current.is_empty() {
-                current.push('/');
-            }
-            current.push_str(segment);
-            folder_paths.insert(current.clone());
-        }
-        let folder_path = folder_segments.join("/");
-        *item_counts.entry(folder_path).or_insert(0) += 1;
-    }
-
-    let mut nodes = HashMap::<String, FolderNode>::new();
-    let mut roots = BTreeSet::<String>::new();
-
-    for path in &folder_paths {
-        let name = path.split('/').last().unwrap_or(path).to_string();
-        nodes.insert(
-            path.clone(),
-            FolderNode {
-                name,
-                path: path.clone(),
-                item_count: *item_counts.get(path).unwrap_or(&0),
-                total_count: 0,
-                children: BTreeSet::new(),
-            },
-        );
-    }
-
-    for path in &folder_paths {
-        if let Some((parent, _)) = path.rsplit_once('/') {
-            if let Some(parent_node) = nodes.get_mut(parent) {
-                parent_node.children.insert(path.clone());
-            }
-        } else {
-            roots.insert(path.clone());
-        }
-    }
-
-    fn compute_total(path: &str, nodes: &mut HashMap<String, FolderNode>) -> usize {
-        let child_paths = nodes
-            .get(path)
-            .map(|node| node.children.iter().cloned().collect::<Vec<_>>())
-            .unwrap_or_default();
-        let mut total = nodes.get(path).map(|node| node.item_count).unwrap_or(0);
-        for child in child_paths {
-            total += compute_total(&child, nodes);
-        }
-        if let Some(node) = nodes.get_mut(path) {
-            node.total_count = total;
-        }
-        total
-    }
-
-    for root in roots.clone() {
-        compute_total(&root, &mut nodes);
-    }
-
-    fn node_to_json(path: &str, nodes: &HashMap<String, FolderNode>) -> serde_json::Value {
-        let node = match nodes.get(path) {
-            Some(node) => node,
-            None => return serde_json::json!({}),
-        };
-        let children: Vec<_> = node
-            .children
-            .iter()
-            .map(|child| node_to_json(child, nodes))
-            .collect();
-        serde_json::json!({
-            "name": node.name,
-            "path": node.path,
-            "item_count": node.item_count,
-            "total_count": node.total_count,
-            "children": children,
-        })
-    }
-
-    let tree: Vec<_> = roots.iter().map(|path| node_to_json(path, &nodes)).collect();
-    serde_json::to_string(&serde_json::json!({
-        "items_without_folder": items_without_folder,
-        "tree": tree,
-    }))
-    .unwrap_or_else(|_| "{\"items_without_folder\":0,\"tree\":[]}".to_string())
+    serde_json::to_string(&build_folder_tree(items))
+        .unwrap_or_else(|_| "{\"items_without_folder\":0,\"tree\":[]}".to_string())
 }
 
 fn rebuild_filtered_items(model: &mut AppModelRust) {
-    let category = model.current_category.to_string();
-    let filter = category_filter_for(&category);
     let selected_folder = model.selected_folder.to_string();
-    model.filtered_indices.clear();
-    for (idx, item) in model.items.iter().enumerate() {
-        if item_matches_filters(item, &category, filter.as_ref(), &selected_folder) {
-            model.filtered_indices.push(idx);
-        }
-    }
-    model.filtered_items_count = model.filtered_indices.len() as i32;
-}
-
-fn category_filter_for(category_id: &str) -> Option<CategoryFilter> {
-    ui_categories_schema()
-        .categories
-        .iter()
-        .cloned()
-        .find(|cat| cat.id == category_id)
-        .and_then(|cat| cat.filter)
-}
-
-fn item_matches_filters(
-    item: &zann_ffi::ItemSummary,
-    category_id: &str,
-    filter: Option<&CategoryFilter>,
-    selected_folder: &str,
-) -> bool {
-    if let Some(filter) = filter {
-        if let Some(is_deleted) = filter.is_deleted {
-            if is_deleted != item.deleted {
-                return false;
-            }
-        }
-        if let Some(type_ids) = &filter.type_ids {
-            if !type_ids.iter().any(|tid| tid == &item.type_id) {
-                return false;
-            }
-        }
-    } else if category_id == "trash" && !item.deleted {
-        return false;
-    }
-
-    if selected_folder.is_empty() {
-        return true;
-    }
-    if selected_folder == "__no_folder__" {
-        return !item.path.contains('/');
-    }
-    let Some((folder_path, _)) = item.path.rsplit_once('/') else {
-        return false;
+    let filter = ItemFilter {
+        category_id: Some(model.current_category.to_string()),
+        folder: match selected_folder.as_str() {
+            "" => FolderFilter::Any,
+            NO_FOLDER_SENTINEL => FolderFilter::WithoutFolder,
+            path => FolderFilter::Path(path.to_string()),
+        },
+        // The backend already applied the search query when listing items.
+        query: String::new(),
     };
-    folder_path == selected_folder || folder_path.starts_with(&format!("{}/", selected_folder))
-}
-
-fn ui_categories_schema() -> &'static UiCategoriesSchema {
-    static SCHEMA: OnceLock<UiCategoriesSchema> = OnceLock::new();
-    SCHEMA.get_or_init(|| serde_json::from_str(UI_CATEGORIES_SCHEMA).unwrap_or(UiCategoriesSchema {
-        categories: Vec::new(),
-        fallback_category_id: "all".to_string(),
-    }))
-}
-
-fn generate_totp_internal(
-    secret: &str,
-    algorithm: &str,
-    digits: i32,
-    period: i32,
-) -> Result<String, String> {
-    let algorithm = parse_totp_algorithm(algorithm)?;
-    let digits = parse_totp_digits(digits)?;
-    let period = parse_totp_period(period)?;
-    let secret_bytes = decode_totp_secret(secret)?;
-
-    let totp = TOTP::new(algorithm, digits as usize, 1, period as u64, secret_bytes)
-        .map_err(|err| err.to_string())?;
-
-    let code = totp.generate_current().map_err(|err| err.to_string())?;
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|_| "invalid system time".to_string())?
-        .as_secs();
-
-    let remaining = period as u64 - (now % period as u64);
-
-    Ok(serde_json::json!({
-        "code": code,
-        "remaining": remaining,
-        "period": period
-    })
-    .to_string())
-}
-
-fn parse_totp_algorithm(value: &str) -> Result<Algorithm, String> {
-    let normalized = if value.is_empty() {
-        "SHA1"
-    } else {
-        value.trim()
-    }
-    .to_uppercase();
-
-    match normalized.as_str() {
-        "SHA1" => Ok(Algorithm::SHA1),
-        "SHA256" => Ok(Algorithm::SHA256),
-        "SHA512" => Ok(Algorithm::SHA512),
-        _ => Err("unsupported otp algorithm".to_string()),
-    }
-}
-
-fn parse_totp_digits(value: i32) -> Result<u32, String> {
-    let digits = if value <= 0 { 6 } else { value as u32 };
-    match digits {
-        6 | 8 => Ok(digits),
-        _ => Err("unsupported otp digits".to_string()),
-    }
-}
-
-fn parse_totp_period(value: i32) -> Result<u32, String> {
-    let period = if value <= 0 { 30 } else { value as u32 };
-    Ok(period)
-}
-
-fn decode_totp_secret(secret: &str) -> Result<Vec<u8>, String> {
-    let cleaned: String = secret
-        .chars()
-        .filter(|ch| !ch.is_whitespace() && *ch != '-')
-        .collect::<String>()
-        .to_uppercase();
-
-    BASE32
-        .decode(cleaned.as_bytes())
-        .map_err(|_| "invalid otp secret".to_string())
+    model.filtered_indices = filtered_indices(&model.items, &filter);
+    model.filtered_items_count = model.filtered_indices.len() as i32;
 }

--- a/crates/zann-cli/src/modules/shared/actions.rs
+++ b/crates/zann-cli/src/modules/shared/actions.rs
@@ -142,9 +142,7 @@ pub(crate) async fn handle_update(
 
     let has_payload_change = args.stdin || !args.field.is_empty();
     if !has_payload_change && args.new_path.is_none() && args.type_id.is_none() {
-        anyhow::bail!(
-            "Nothing to update: pass --field, --stdin, --new-path or --type-id"
-        );
+        anyhow::bail!("Nothing to update: pass --field, --stdin, --new-path or --type-id");
     }
     let payload = if has_payload_change {
         let type_id = args.type_id.as_deref().unwrap_or("secret");

--- a/crates/zann-client/src/auth.rs
+++ b/crates/zann-client/src/auth.rs
@@ -115,10 +115,7 @@ pub fn insert_pending_login(
     login_id: String,
     pending: PendingLogin,
 ) -> Result<(), String> {
-    let mut guard = state
-        .pending_logins
-        .lock()
-        .map_err(|err| err.to_string())?;
+    let mut guard = state.pending_logins.lock().map_err(|err| err.to_string())?;
     guard.insert(login_id, pending);
     Ok(())
 }
@@ -136,15 +133,11 @@ pub fn update_pending_login_for_fingerprint(
         .as_deref()
         .and_then(|server_id| context_name_for_server_id(state, server_id))
         .unwrap_or_else(|| context_name_from_url(server_url));
-    let Some(existing) =
-        fingerprint_change_for_context(state, &context_name, new_fingerprint)
+    let Some(existing) = fingerprint_change_for_context(state, &context_name, new_fingerprint)
     else {
         return Ok(None);
     };
-    let mut guard = state
-        .pending_logins
-        .lock()
-        .map_err(|err| err.to_string())?;
+    let mut guard = state.pending_logins.lock().map_err(|err| err.to_string())?;
     if let Some(entry) = guard.get_mut(login_id) {
         entry.fingerprint_new = Some(new_fingerprint.to_string());
         entry.fingerprint_trusted = false;
@@ -160,13 +153,11 @@ pub async fn finalize_login(
     result: PendingLoginResult,
 ) -> Result<ApiResponse<OidcLoginStatusResponse>, String> {
     let storage_id_string = apply_login_context(state, &pending.server_url, &result).await?;
-    let personal_status =
-        fetch_personal_status(&pending.server_url, &result.access_token).await.ok();
+    let personal_status = fetch_personal_status(&pending.server_url, &result.access_token)
+        .await
+        .ok();
 
-    let mut guard = state
-        .pending_logins
-        .lock()
-        .map_err(|err| err.to_string())?;
+    let mut guard = state.pending_logins.lock().map_err(|err| err.to_string())?;
     guard.remove(login_id);
 
     Ok(ApiResponse::ok(OidcLoginStatusResponse {
@@ -177,7 +168,9 @@ pub async fn finalize_login(
         email: Some(result.email),
         old_fingerprint: None,
         new_fingerprint: None,
-        personal_vaults_present: personal_status.as_ref().map(|status| status.personal_vaults_present),
+        personal_vaults_present: personal_status
+            .as_ref()
+            .map(|status| status.personal_vaults_present),
         personal_key_envelopes_present: personal_status
             .as_ref()
             .map(|status| status.personal_key_envelopes_present),
@@ -206,8 +199,7 @@ pub async fn fetch_personal_status(
         Err(err) => {
             append_auth_log(&format!(
                 "personal_status_error server={} error={}",
-                server_url,
-                err
+                server_url, err
             ));
             return Err(format!("vault_preflight_failed: {err}"));
         }
@@ -218,10 +210,7 @@ pub async fn fetch_personal_status(
         server_url,
         status.personal_vaults_present,
         status.personal_key_envelopes_present,
-        status
-            .personal_vault_id
-            .as_deref()
-            .unwrap_or("none")
+        status.personal_vault_id.as_deref().unwrap_or("none")
     ));
     Ok(status)
 }
@@ -240,14 +229,16 @@ pub async fn apply_login_context(
         .into_iter()
         .filter(|storage| storage.server_url.as_deref() == Some(server_url))
         .collect::<Vec<_>>();
-    let existing_storage_id = matching_storages.first().map(|storage| storage.id.to_string());
+    let existing_storage_id = matching_storages
+        .first()
+        .map(|storage| storage.id.to_string());
     let token_name = result.token_name.clone();
     let storage_id_string = {
         let context_name = context_name_from_url(server_url);
         let server_id = result.info.server_id.clone();
-        let migrated_storage_id = server_id
-            .as_deref()
-            .and_then(|server_id| migrate_context_for_server_id(&mut config, &context_name, server_id));
+        let migrated_storage_id = server_id.as_deref().and_then(|server_id| {
+            migrate_context_for_server_id(&mut config, &context_name, server_id)
+        });
 
         let context = ensure_context(&mut config, &context_name, server_url);
         if context.storage_id.is_none() {
@@ -298,9 +289,7 @@ pub async fn apply_login_context(
             personal_vaults_enabled: result.info.personal_vaults_enabled,
             auth_method: None,
         };
-        repo.upsert(&storage)
-            .await
-            .map_err(|err| err.to_string())?;
+        repo.upsert(&storage).await.map_err(|err| err.to_string())?;
     }
     Ok(storage_id_string)
 }
@@ -331,7 +320,9 @@ pub fn migrate_context_for_server_id(
 
     let storage_id = old_context.storage_id.clone();
     config.contexts.remove(&old_name);
-    config.contexts.insert(context_name.to_string(), old_context);
+    config
+        .contexts
+        .insert(context_name.to_string(), old_context);
     storage_id
 }
 

--- a/crates/zann-client/src/auth_oidc.rs
+++ b/crates/zann-client/src/auth_oidc.rs
@@ -13,14 +13,16 @@ use crate::auth::{
     finalize_login, oidc_status_error, oidc_status_fingerprint_changed,
     update_pending_login_for_fingerprint,
 };
-use crate::constants::TOKEN_OIDC;
 use crate::config::{ensure_context, load_config, save_config};
+use crate::constants::TOKEN_OIDC;
 use crate::remote::{
     exchange_authorization_code, exchange_oidc_for_session, fetch_me_email, fetch_prelogin,
     fetch_system_info,
 };
 use crate::state::{ClientState, PendingLogin, PendingLoginResult};
-use crate::types::{ApiResponse, OidcConfigResponse, OidcDiscovery, OidcLoginStartResponse, OidcLoginStatusResponse};
+use crate::types::{
+    ApiResponse, OidcConfigResponse, OidcDiscovery, OidcLoginStartResponse, OidcLoginStatusResponse,
+};
 use crate::util::context_name_from_url;
 
 fn random_url_safe(size: usize) -> String {
@@ -60,16 +62,34 @@ fn log_jwt_summary(label: &str, token: &str) {
     };
     let header_json: serde_json::Value = serde_json::from_slice(&header).unwrap_or_default();
     let payload_json: serde_json::Value = serde_json::from_slice(&payload).unwrap_or_default();
-    let alg = header_json.get("alg").and_then(|v| v.as_str()).unwrap_or("unknown");
-    let kid = header_json.get("kid").and_then(|v| v.as_str()).unwrap_or("unknown");
-    let iss = payload_json.get("iss").and_then(|v| v.as_str()).unwrap_or("unknown");
+    let alg = header_json
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let kid = header_json
+        .get("kid")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let iss = payload_json
+        .get("iss")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
     let aud = payload_json
         .get("aud")
         .map(|v| v.to_string())
         .unwrap_or_else(|| "unknown".to_string());
-    let azp = payload_json.get("azp").and_then(|v| v.as_str()).unwrap_or("unknown");
-    let typ = header_json.get("typ").and_then(|v| v.as_str()).unwrap_or("unknown");
-    let exp = payload_json.get("exp").and_then(|v| v.as_i64()).unwrap_or(0);
+    let azp = payload_json
+        .get("azp")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let typ = header_json
+        .get("typ")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let exp = payload_json
+        .get("exp")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
     println!(
         "[oidc] {label} summary alg={alg} kid={kid} typ={typ} iss={iss} aud={aud} azp={azp} exp={exp}"
     );
@@ -81,7 +101,10 @@ pub async fn begin_login(
     status_tx: Sender<OidcLoginStatusResponse>,
 ) -> Result<ApiResponse<OidcLoginStartResponse>, String> {
     if server_url.trim().is_empty() {
-        return Ok(ApiResponse::err("invalid_server_url", "server_url is required"));
+        return Ok(ApiResponse::err(
+            "invalid_server_url",
+            "server_url is required",
+        ));
     }
     let client = reqwest::Client::new();
     let oidc_config_url = format!("{}/v1/auth/oidc/config", server_url.trim_end_matches('/'));
@@ -91,8 +114,8 @@ pub async fn begin_login(
     let discovery = crate::http::fetch_json::<OidcDiscovery>(&client, &discovery_url).await?;
 
     let redirect_port = 8765;
-    let listener = TcpListener::bind(format!("127.0.0.1:{redirect_port}"))
-        .map_err(|err| err.to_string())?;
+    let listener =
+        TcpListener::bind(format!("127.0.0.1:{redirect_port}")).map_err(|err| err.to_string())?;
     let redirect_uri = format!("http://127.0.0.1:{}/oidc/callback", redirect_port);
 
     let oauth_state = random_url_safe(16);
@@ -118,10 +141,7 @@ pub async fn begin_login(
 
     let login_id = Uuid::now_v7().to_string();
     let login_id_for_thread = login_id.clone();
-    let mut guard = state
-        .pending_logins
-        .lock()
-        .map_err(|err| err.to_string())?;
+    let mut guard = state.pending_logins.lock().map_err(|err| err.to_string())?;
     guard.insert(
         login_id.clone(),
         PendingLogin {
@@ -163,17 +183,20 @@ pub async fn trust_fingerprint(
     status_tx: Sender<OidcLoginStatusResponse>,
 ) -> Result<ApiResponse<()>, String> {
     let pending = {
-        let mut guard = state
-            .pending_logins
-            .lock()
-            .map_err(|err| err.to_string())?;
+        let mut guard = state.pending_logins.lock().map_err(|err| err.to_string())?;
         guard.get_mut(&login_id).cloned()
     };
     let Some(pending) = pending else {
-        return Ok(ApiResponse::err("login_not_found", "login session not found"));
+        return Ok(ApiResponse::err(
+            "login_not_found",
+            "login session not found",
+        ));
     };
     let Some(new_fp) = pending.fingerprint_new.clone() else {
-        return Ok(ApiResponse::err("fingerprint_missing", "no new fingerprint to trust"));
+        return Ok(ApiResponse::err(
+            "fingerprint_missing",
+            "no new fingerprint to trust",
+        ));
     };
 
     let mut config = load_config(&state.root).unwrap_or_else(|_| Default::default());
@@ -184,10 +207,7 @@ pub async fn trust_fingerprint(
         context.server_id = result.info.server_id.clone();
     }
     save_config(&state.root, &config).map_err(|err| err.to_string())?;
-    let mut guard = state
-        .pending_logins
-        .lock()
-        .map_err(|err| err.to_string())?;
+    let mut guard = state.pending_logins.lock().map_err(|err| err.to_string())?;
     if let Some(entry) = guard.get_mut(&login_id) {
         entry.fingerprint_trusted = true;
         if let Some(result) = entry.pending_result.clone() {
@@ -197,13 +217,15 @@ pub async fn trust_fingerprint(
             let status_tx = status_tx.clone();
             std::thread::spawn(move || {
                 let runtime = tokio::runtime::Runtime::new().expect("runtime");
-                let response = runtime.block_on(finalize_login(&state_clone, &login_id, pending, result));
+                let response =
+                    runtime.block_on(finalize_login(&state_clone, &login_id, pending, result));
                 match response {
                     Ok(payload) => {
                         if let Some(data) = payload.data {
                             let _ = status_tx.send(data);
                         } else {
-                            let _ = status_tx.send(oidc_status_error(&login_id, "missing login payload"));
+                            let _ = status_tx
+                                .send(oidc_status_error(&login_id, "missing login payload"));
                         }
                     }
                     Err(err) => {
@@ -320,7 +342,11 @@ fn parse_oidc_request(
     Ok((code, state))
 }
 
-fn respond_html(stream: &mut std::net::TcpStream, title: &str, message: &str) -> Result<(), String> {
+fn respond_html(
+    stream: &mut std::net::TcpStream,
+    title: &str,
+    message: &str,
+) -> Result<(), String> {
     let body = format!(
         "<!doctype html><html><head><meta charset=\"utf-8\"><title>{}</title></head>\
         <body style=\"font-family: sans-serif; padding: 24px;\"><h2>{}</h2><p>{}</p></body></html>",
@@ -331,7 +357,9 @@ fn respond_html(stream: &mut std::net::TcpStream, title: &str, message: &str) ->
         body.len(),
         body
     );
-    stream.write_all(response.as_bytes()).map_err(|err| err.to_string())
+    stream
+        .write_all(response.as_bytes())
+        .map_err(|err| err.to_string())
 }
 
 async fn complete_oidc_login(
@@ -342,10 +370,7 @@ async fn complete_oidc_login(
     status_tx: Sender<OidcLoginStatusResponse>,
 ) -> Result<(), String> {
     let pending = {
-        let guard = state
-            .pending_logins
-            .lock()
-            .map_err(|err| err.to_string())?;
+        let guard = state.pending_logins.lock().map_err(|err| err.to_string())?;
         guard.get(&login_id).cloned()
     };
     let Some(pending) = pending else {
@@ -434,7 +459,11 @@ async fn complete_oidc_login(
         &result,
     )? {
         println!("[oidc] fingerprint changed for {}", pending.server_url);
-        let _ = status_tx.send(oidc_status_fingerprint_changed(&login_id, &existing, &info.server_fingerprint));
+        let _ = status_tx.send(oidc_status_fingerprint_changed(
+            &login_id,
+            &existing,
+            &info.server_fingerprint,
+        ));
         return Ok(());
     }
 

--- a/crates/zann-client/src/auth_password.rs
+++ b/crates/zann-client/src/auth_password.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::constants::TOKEN_SESSION;
-use crate::remote::{fetch_prelogin, fetch_system_info};
 use crate::auth::{
     apply_login_context, context_name_for_server_id, empty_oidc_config, empty_oidc_discovery,
     fetch_personal_status, fingerprint_change_for_context, insert_pending_login,
 };
+use crate::constants::TOKEN_SESSION;
+use crate::remote::{fetch_prelogin, fetch_system_info};
 use crate::state::{ClientState, PendingLogin, PendingLoginResult};
 use crate::types::ApiResponse;
 use crate::util::context_name_from_url;
@@ -133,10 +133,16 @@ pub async fn password_login(
         server_url, email
     );
     if server_url.trim().is_empty() {
-        return Ok(ApiResponse::err("invalid_server_url", "server_url is required"));
+        return Ok(ApiResponse::err(
+            "invalid_server_url",
+            "server_url is required",
+        ));
     }
     if email.trim().is_empty() || password.trim().is_empty() {
-        return Ok(ApiResponse::err("invalid_credentials", "email and password are required"));
+        return Ok(ApiResponse::err(
+            "invalid_credentials",
+            "email and password are required",
+        ));
     }
 
     let client = reqwest::Client::new();
@@ -206,8 +212,9 @@ pub async fn password_login(
     }
 
     let storage_id = apply_login_context(state, &server_url, &result).await?;
-    let personal_status =
-        fetch_personal_status(&server_url, &result.access_token).await.ok();
+    let personal_status = fetch_personal_status(&server_url, &result.access_token)
+        .await
+        .ok();
     Ok(ApiResponse::ok(password_success(
         email,
         storage_id,
@@ -227,10 +234,16 @@ pub async fn password_register(
         server_url, email
     );
     if server_url.trim().is_empty() {
-        return Ok(ApiResponse::err("invalid_server_url", "server_url is required"));
+        return Ok(ApiResponse::err(
+            "invalid_server_url",
+            "server_url is required",
+        ));
     }
     if email.trim().is_empty() || password.trim().is_empty() {
-        return Ok(ApiResponse::err("invalid_credentials", "email and password are required"));
+        return Ok(ApiResponse::err(
+            "invalid_credentials",
+            "email and password are required",
+        ));
     }
 
     let client = reqwest::Client::new();
@@ -309,8 +322,9 @@ pub async fn password_register(
     }
 
     let storage_id = apply_login_context(state, &server_url, &result).await?;
-    let personal_status =
-        fetch_personal_status(&server_url, &result.access_token).await.ok();
+    let personal_status = fetch_personal_status(&server_url, &result.access_token)
+        .await
+        .ok();
     Ok(ApiResponse::ok(password_success(
         email,
         storage_id,

--- a/crates/zann-client/src/config.rs
+++ b/crates/zann-client/src/config.rs
@@ -17,12 +17,14 @@ pub fn save_config(root: &Path, config: &CliConfig) -> Result<(), anyhow::Error>
     let path = root.join(CONFIG_FILENAME);
     let new_value = serde_json::to_value(config)?;
     let merged_value = if let Ok(existing) = std::fs::read_to_string(&path) {
-        if let (Ok(mut existing_value), serde_json::Value::Object(new_map)) =
-            (serde_json::from_str::<serde_json::Value>(&existing), new_value.clone())
-        {
+        if let (Ok(mut existing_value), serde_json::Value::Object(new_map)) = (
+            serde_json::from_str::<serde_json::Value>(&existing),
+            new_value.clone(),
+        ) {
             if let serde_json::Value::Object(existing_map) = &mut existing_value {
                 for (key, value) in new_map {
-                    if key == "identity" && value.is_null() && existing_map.contains_key("identity") {
+                    if key == "identity" && value.is_null() && existing_map.contains_key("identity")
+                    {
                         continue;
                     }
                     existing_map.insert(key, value);

--- a/crates/zann-client/src/crypto.rs
+++ b/crates/zann-client/src/crypto.rs
@@ -9,8 +9,7 @@ pub fn decrypt_vault_key_with_master(
     master_key: &SecretKey,
     vault: &zann_db::local::LocalVault,
 ) -> Result<SecretKey, String> {
-    let blob = EncryptedBlob::from_bytes(&vault.vault_key_enc)
-        .map_err(|err| err.to_string())?;
+    let blob = EncryptedBlob::from_bytes(&vault.vault_key_enc).map_err(|err| err.to_string())?;
     let aad = vault_key_aad(vault.id);
     let key_bytes = decrypt_blob(master_key, &blob, &aad).map_err(|err| err.to_string())?;
     if key_bytes.len() != 32 {
@@ -51,7 +50,10 @@ pub fn decrypt_payload(
 }
 
 #[allow(dead_code)]
-pub fn derive_master_key(password: &str, identity: &IdentityConfig) -> Result<SecretKey, anyhow::Error> {
+pub fn derive_master_key(
+    password: &str,
+    identity: &IdentityConfig,
+) -> Result<SecretKey, anyhow::Error> {
     if identity.kdf_params.algorithm != "argon2id" {
         anyhow::bail!("unsupported kdf algorithm");
     }

--- a/crates/zann-client/src/http.rs
+++ b/crates/zann-client/src/http.rs
@@ -40,14 +40,15 @@ pub async fn fetch_json<T: for<'de> serde::Deserialize<'de>>(
     client: &reqwest::Client,
     url: &str,
 ) -> Result<T, String> {
-    let response = client.get(url).send().await.map_err(|err| err.to_string())?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
         return Err(format!("Request failed: {status} {body}"));
     }
-    response
-        .json::<T>()
-        .await
-        .map_err(|err| err.to_string())
+    response.json::<T>().await.map_err(|err| err.to_string())
 }

--- a/crates/zann-client/src/identity.rs
+++ b/crates/zann-client/src/identity.rs
@@ -1,7 +1,7 @@
 use base64::Engine;
 use chrono::Utc;
 use data_encoding::BASE32_NOPAD;
-use ed25519_dalek::{Signature, VerifyingKey, Verifier};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use sha2::{Digest, Sha256};
 
 use crate::types::SystemInfoResponse;
@@ -20,13 +20,11 @@ pub enum IdentityError {
 }
 
 pub fn verify_system_identity(info: &SystemInfoResponse) -> Result<(), IdentityError> {
-    let server_id = info
-        .server_id
-        .as_deref()
-        .ok_or(IdentityError::Missing)?;
+    let server_id = info.server_id.as_deref().ok_or(IdentityError::Missing)?;
     let identity = info.identity.as_ref().ok_or(IdentityError::Missing)?;
 
-    let public_key_bytes = decode_b64(&identity.public_key).map_err(|_| IdentityError::InvalidKey)?;
+    let public_key_bytes =
+        decode_b64(&identity.public_key).map_err(|_| IdentityError::InvalidKey)?;
     if public_key_bytes.len() != 32 {
         return Err(IdentityError::InvalidKey);
     }
@@ -38,8 +36,8 @@ pub fn verify_system_identity(info: &SystemInfoResponse) -> Result<(), IdentityE
 
     let signature_bytes =
         decode_b64(&identity.signature).map_err(|_| IdentityError::InvalidSignatureBytes)?;
-    let signature =
-        Signature::try_from(signature_bytes.as_slice()).map_err(|_| IdentityError::InvalidSignatureBytes)?;
+    let signature = Signature::try_from(signature_bytes.as_slice())
+        .map_err(|_| IdentityError::InvalidSignatureBytes)?;
     let public_key_array: [u8; 32] = public_key_bytes
         .as_slice()
         .try_into()

--- a/crates/zann-client/src/lib.rs
+++ b/crates/zann-client/src/lib.rs
@@ -18,4 +18,7 @@ pub mod auth_password;
 pub mod sync;
 pub mod sync_helpers;
 
-pub use state::{CliConfig, CliContext, ClientState, IdentityConfig, PendingLogin, PendingLoginResult, TokenEntry};
+pub use state::{
+    CliConfig, CliContext, ClientState, IdentityConfig, PendingLogin, PendingLoginResult,
+    TokenEntry,
+};

--- a/crates/zann-client/src/remote.rs
+++ b/crates/zann-client/src/remote.rs
@@ -4,8 +4,8 @@ use serde::Deserialize;
 use crate::http::fetch_json;
 use crate::identity::{verify_system_identity, IdentityError};
 use crate::types::{
-    OidcConfigResponse, OidcDiscovery, OidcExchangeResponse, SystemInfoResponse, TokenErrorResponse,
-    TokenResponse,
+    OidcConfigResponse, OidcDiscovery, OidcExchangeResponse, SystemInfoResponse,
+    TokenErrorResponse, TokenResponse,
 };
 
 pub async fn exchange_authorization_code(
@@ -89,9 +89,9 @@ pub async fn fetch_system_info(
 fn format_identity_error(err: IdentityError) -> String {
     match err {
         IdentityError::Missing => "server_identity_missing".to_string(),
-        IdentityError::InvalidId | IdentityError::InvalidKey | IdentityError::InvalidSignatureBytes => {
-            "server_identity_invalid".to_string()
-        }
+        IdentityError::InvalidId
+        | IdentityError::InvalidKey
+        | IdentityError::InvalidSignatureBytes => "server_identity_invalid".to_string(),
         IdentityError::InvalidSignature => "server_identity_invalid".to_string(),
         IdentityError::TimeSkew { skew_seconds } => format!("server_time_skew:{skew_seconds}"),
     }
@@ -130,7 +130,11 @@ pub async fn fetch_prelogin(
     let base = format!("{}/v1/auth/prelogin", addr.trim_end_matches('/'));
     let mut url = reqwest::Url::parse(&base).map_err(|err| err.to_string())?;
     url.query_pairs_mut().append_pair("email", email);
-    let response = client.get(url).send().await.map_err(|err| err.to_string())?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();

--- a/crates/zann-client/src/sync.rs
+++ b/crates/zann-client/src/sync.rs
@@ -5,12 +5,12 @@ use zann_db::local::{
     LocalStorageRepo, LocalSyncCursor, LocalVaultRepo, PendingChangeRepo, SyncCursorRepo,
 };
 
-use crate::crypto::{decrypt_vault_key_with_master, vault_key_aad};
-use crate::tokens::ensure_access_token_for_context;
 use crate::config::{load_config, save_config};
+use crate::crypto::{decrypt_vault_key_with_master, vault_key_aad};
 use crate::http::{auth_headers, decode_json_response, ensure_success};
 use crate::remote::fetch_system_info;
 use crate::state::ClientState;
+use crate::tokens::ensure_access_token_for_context;
 use crate::types::{
     ApiResponse, SyncPullRequest, SyncPullResponse, SyncPushChange, SyncPushRequest,
     SyncPushResponse, SyncSharedPullResponse, SyncSharedPushRequest, VaultListResponse,
@@ -30,7 +30,6 @@ pub async fn remote_sync(
     state: &ClientState,
     master_key: &SecretKey,
 ) -> Result<ApiResponse<serde_json::Value>, String> {
-
     let mut config = load_config(&state.root).unwrap_or_else(|_| Default::default());
     let context_name = config
         .current_context
@@ -153,8 +152,7 @@ pub async fn remote_sync(
     for vault in &vault_details {
         let encryption_type = VaultEncryptionType::try_from(vault.encryption_type)
             .map_err(|_| "invalid vault encryption type".to_string())?;
-        let kind = VaultKind::try_from(vault.kind)
-            .map_err(|_| "invalid vault kind".to_string())?;
+        let kind = VaultKind::try_from(vault.kind).map_err(|_| "invalid vault kind".to_string())?;
         if encryption_type != VaultEncryptionType::Client || kind != VaultKind::Personal {
             continue;
         }
@@ -174,8 +172,8 @@ pub async fn remote_sync(
         }
         let vault_key = SecretKey::generate();
         let aad = vault_key_aad(vault_id);
-        let blob = encrypt_blob(master_key, vault_key.as_bytes(), &aad)
-            .map_err(|err| err.to_string())?;
+        let blob =
+            encrypt_blob(master_key, vault_key.as_bytes(), &aad).map_err(|err| err.to_string())?;
         let master_fp = key_fingerprint(master_key);
         let payload = serde_json::json!({ "vault_key_enc": blob.to_bytes() });
         let url = format!("{}/v1/vaults/{}/key", addr.trim_end_matches('/'), vault.id);
@@ -196,7 +194,12 @@ pub async fn remote_sync(
             }
         }
         let _ = vault_repo
-            .update_key(storage_uuid, vault_id, &blob.to_bytes(), KeyWrapType::RemoteStrict)
+            .update_key(
+                storage_uuid,
+                vault_id,
+                &blob.to_bytes(),
+                KeyWrapType::RemoteStrict,
+            )
             .await;
     }
 
@@ -212,8 +215,7 @@ pub async fn remote_sync(
         };
         let encryption_type = VaultEncryptionType::try_from(vault.encryption_type)
             .map_err(|_| "invalid vault encryption type".to_string())?;
-        let kind = VaultKind::try_from(vault.kind)
-            .map_err(|_| "invalid vault kind".to_string())?;
+        let kind = VaultKind::try_from(vault.kind).map_err(|_| "invalid vault kind".to_string())?;
         let should_be_shared =
             encryption_type == VaultEncryptionType::Server && kind == VaultKind::Shared;
         let desired_wrap = if should_be_shared {
@@ -430,18 +432,15 @@ pub async fn remote_sync(
                     Ok(response) => response,
                     Err(_) => break,
                 };
-                let pull = resp.json::<SyncPullResponse>().await.map_err(|err| err.to_string())?;
+                let pull = resp
+                    .json::<SyncPullResponse>()
+                    .await
+                    .map_err(|err| err.to_string())?;
 
                 for change in &pull.changes {
-                    if apply_pull_change(
-                        &item_repo,
-                        &history_repo,
-                        storage_uuid,
-                        vault_id,
-                        change,
-                    )
-                    .await
-                    .is_ok()
+                    if apply_pull_change(&item_repo, &history_repo, storage_uuid, vault_id, change)
+                        .await
+                        .is_ok()
                     {
                         applied_total += 1;
                     }

--- a/crates/zann-client/src/sync_helpers.rs
+++ b/crates/zann-client/src/sync_helpers.rs
@@ -116,8 +116,7 @@ pub async fn ensure_local_vaults(
         } else {
             KeyWrapType::RemoteStrict
         };
-        let kind = VaultKind::try_from(vault.kind)
-            .map_err(|_| "invalid vault kind".to_string())?;
+        let kind = VaultKind::try_from(vault.kind).map_err(|_| "invalid vault kind".to_string())?;
         let record = LocalVault {
             id: vault_id,
             storage_id: storage_uuid,
@@ -147,7 +146,10 @@ pub async fn handle_sync_conflict(
         .checksum
         .clone()
         .unwrap_or_else(|| payload_checksum(&payload_enc));
-    let path = change.path.clone().unwrap_or_else(|| "conflict".to_string());
+    let path = change
+        .path
+        .clone()
+        .unwrap_or_else(|| "conflict".to_string());
     let name = change.name.clone().unwrap_or_else(|| path.clone());
     let type_id = change
         .type_id
@@ -180,7 +182,10 @@ pub async fn handle_sync_conflict(
         existing.checksum = checksum;
         existing.sync_status = SyncStatus::Conflict;
         existing.updated_at = now;
-        item_repo.update(&existing).await.map_err(|err| err.to_string())?;
+        item_repo
+            .update(&existing)
+            .await
+            .map_err(|err| err.to_string())?;
         return Ok(Some(existing.id));
     }
 
@@ -333,7 +338,10 @@ pub async fn apply_pull_change(
         } else {
             SyncStatus::Synced
         };
-        item_repo.update(&existing).await.map_err(|err| err.to_string())?;
+        item_repo
+            .update(&existing)
+            .await
+            .map_err(|err| err.to_string())?;
     } else {
         let record = LocalItem {
             id: item_id,
@@ -354,7 +362,10 @@ pub async fn apply_pull_change(
                 SyncStatus::Synced
             },
         };
-        item_repo.create(&record).await.map_err(|err| err.to_string())?;
+        item_repo
+            .create(&record)
+            .await
+            .map_err(|err| err.to_string())?;
     }
 
     let history_entries = change
@@ -368,8 +379,7 @@ pub async fn apply_pull_change(
             payload_enc: entry.payload_enc.clone(),
             checksum: entry.checksum.clone(),
             version: entry.version,
-            change_type: ChangeType::try_from(entry.change_type)
-                .unwrap_or(ChangeType::Update),
+            change_type: ChangeType::try_from(entry.change_type).unwrap_or(ChangeType::Update),
             changed_by_email: entry.changed_by_email.clone(),
             changed_by_name: entry.changed_by_name.clone(),
             changed_by_device_id: None,
@@ -438,7 +448,10 @@ pub async fn apply_shared_pull_change(
         } else {
             SyncStatus::Synced
         };
-        item_repo.update(&existing).await.map_err(|err| err.to_string())?;
+        item_repo
+            .update(&existing)
+            .await
+            .map_err(|err| err.to_string())?;
     } else {
         let record = LocalItem {
             id: item_id,
@@ -459,7 +472,10 @@ pub async fn apply_shared_pull_change(
                 SyncStatus::Synced
             },
         };
-        item_repo.create(&record).await.map_err(|err| err.to_string())?;
+        item_repo
+            .create(&record)
+            .await
+            .map_err(|err| err.to_string())?;
     }
 
     let history_entries = change
@@ -475,8 +491,7 @@ pub async fn apply_shared_pull_change(
                 .unwrap_or_default(),
             checksum: entry.checksum.clone(),
             version: entry.version,
-            change_type: ChangeType::try_from(entry.change_type)
-                .unwrap_or(ChangeType::Update),
+            change_type: ChangeType::try_from(entry.change_type).unwrap_or(ChangeType::Update),
             changed_by_email: entry.changed_by_email.clone(),
             changed_by_name: entry.changed_by_name.clone(),
             changed_by_device_id: None,

--- a/crates/zann-client/src/tokens.rs
+++ b/crates/zann-client/src/tokens.rs
@@ -26,10 +26,7 @@ pub async fn ensure_access_token_for_context(
         .cloned()
         .ok_or_else(|| "token entry not found".to_string())?;
 
-    let expires_at = entry
-        .access_expires_at
-        .as_deref()
-        .and_then(parse_rfc3339);
+    let expires_at = entry.access_expires_at.as_deref().and_then(parse_rfc3339);
     let needs_refresh = expires_at
         .map(|expires_at| Utc::now() + ChronoDuration::seconds(REFRESH_SKEW_SECONDS) >= expires_at)
         .unwrap_or(false);
@@ -69,8 +66,7 @@ pub async fn ensure_access_token_for_context(
         expires_in: u64,
     }
     let auth: AuthResponse = response.json().await.map_err(|err| err.to_string())?;
-    let new_expires =
-        (Utc::now() + ChronoDuration::seconds(auth.expires_in as i64)).to_rfc3339();
+    let new_expires = (Utc::now() + ChronoDuration::seconds(auth.expires_in as i64)).to_rfc3339();
 
     if let Some(ctx) = config.contexts.get_mut(context_name) {
         if let Some(entry) = ctx.tokens.get_mut(token_name) {

--- a/crates/zann-client/tests/config.rs
+++ b/crates/zann-client/tests/config.rs
@@ -31,7 +31,8 @@ fn save_config_preserves_identity_when_missing() {
         identity: Some(identity.clone()),
     };
 
-    let initial_contents = serde_json::to_string_pretty(&initial_config).expect("serialize initial");
+    let initial_contents =
+        serde_json::to_string_pretty(&initial_config).expect("serialize initial");
     fs::write(&config_path, initial_contents).expect("write initial config");
 
     let mut contexts = HashMap::new();
@@ -72,10 +73,22 @@ fn save_config_preserves_identity_when_missing() {
     assert!(saved.contexts.contains_key("new"));
     let saved_identity = saved.identity.expect("identity preserved");
     assert_eq!(saved_identity.kdf_salt, identity.kdf_salt);
-    assert_eq!(saved_identity.kdf_params.algorithm, identity.kdf_params.algorithm);
-    assert_eq!(saved_identity.kdf_params.iterations, identity.kdf_params.iterations);
-    assert_eq!(saved_identity.kdf_params.memory_kb, identity.kdf_params.memory_kb);
-    assert_eq!(saved_identity.kdf_params.parallelism, identity.kdf_params.parallelism);
+    assert_eq!(
+        saved_identity.kdf_params.algorithm,
+        identity.kdf_params.algorithm
+    );
+    assert_eq!(
+        saved_identity.kdf_params.iterations,
+        identity.kdf_params.iterations
+    );
+    assert_eq!(
+        saved_identity.kdf_params.memory_kb,
+        identity.kdf_params.memory_kb
+    );
+    assert_eq!(
+        saved_identity.kdf_params.parallelism,
+        identity.kdf_params.parallelism
+    );
     assert_eq!(saved_identity.salt_fingerprint, identity.salt_fingerprint);
     assert_eq!(saved_identity.first_seen_at, identity.first_seen_at);
     assert_eq!(saved_identity.email, identity.email);

--- a/crates/zann-db/src/services/items.rs
+++ b/crates/zann-db/src/services/items.rs
@@ -56,9 +56,10 @@ impl<'a> ItemsService for LocalServices<'a> {
             .as_deref()
             .and_then(|query| build_fts_query(query.trim()));
         let cursor = match params.cursor.as_deref() {
-            Some(cursor) => Some(parse_cursor(cursor).ok_or_else(|| {
-                ServiceError::new("invalid_cursor", "invalid cursor")
-            })?),
+            Some(cursor) => Some(
+                parse_cursor(cursor)
+                    .ok_or_else(|| ServiceError::new("invalid_cursor", "invalid cursor"))?,
+            ),
             None => None,
         };
         let repo = LocalItemRepo::new(self.pool);
@@ -119,7 +120,13 @@ impl<'a> ItemsService for LocalServices<'a> {
                 .await
                 .map_err(|err| ServiceError::new("item_list_failed", err.to_string()))?,
             None => repo
-                .list_by_vault_paged(storage_id, vault_id, params.include_deleted, limit + 1, cursor)
+                .list_by_vault_paged(
+                    storage_id,
+                    vault_id,
+                    params.include_deleted,
+                    limit + 1,
+                    cursor,
+                )
                 .await
                 .map_err(|err| ServiceError::new("item_list_failed", err.to_string()))?,
         };

--- a/crates/zann-ffi/Cargo.toml
+++ b/crates/zann-ffi/Cargo.toml
@@ -19,6 +19,7 @@ zann-core = { path = "../zann-core", features = ["sqlite"] }
 zann-crypto = { path = "../zann-crypto" }
 zann-db = { path = "../zann-db", features = ["sqlite"] }
 zann-client = { path = "../zann-client" }
+zann-ui-core = { path = "../zann-ui-core" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/zann-ffi/src/lib.rs
+++ b/crates/zann-ffi/src/lib.rs
@@ -6,17 +6,17 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::runtime::Runtime;
 use uuid::Uuid;
+use zann_client::state::ClientState;
+use zann_client::sync_helpers::key_fingerprint;
 use zann_core::{ItemCounts, ItemListParams, ItemsService, VaultsService};
 use zann_crypto::crypto::SecretKey;
 use zann_crypto::passwords::{kdf_fingerprint, KdfParams as CryptoKdfParams};
-use zann_crypto::EncryptedPayload;
 use zann_crypto::secrets::{FieldKind, FieldValue};
 use zann_crypto::vault_crypto;
+use zann_crypto::EncryptedPayload;
 use zann_db::local::{LocalItemRepo, LocalStorage, LocalStorageRepo, LocalVaultRepo};
 use zann_db::services::LocalServices;
 use zann_db::{connect_sqlite_with_max, migrate_local, SqlitePool};
-use zann_client::state::ClientState;
-use zann_client::sync_helpers::key_fingerprint;
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum CoreError {
@@ -129,7 +129,7 @@ pub struct StorageSummaryFfi {
 
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct AppStatusFfi {
-    pub initialized: bool,    // master password has been set (vaults exist)
+    pub initialized: bool, // master password has been set (vaults exist)
     pub locked: bool,
     pub storages_count: u64,
     pub has_local_vault: bool,
@@ -146,10 +146,7 @@ pub struct CoreFacade {
 }
 
 impl CoreFacade {
-    fn services_with_key<'a>(
-        &'a self,
-        master_key: &'a SecretKey,
-    ) -> LocalServices<'a> {
+    fn services_with_key<'a>(&'a self, master_key: &'a SecretKey) -> LocalServices<'a> {
         LocalServices::new(&self.pool, master_key)
     }
 
@@ -261,15 +258,9 @@ impl CoreFacade {
             let vault = self.runtime_block_on(services.ensure_default_local_personal())?;
             vault.id
         } else {
-            let verify = vaults
-                .first()
-                .expect("vaults not empty");
-            vault_crypto::decrypt_vault_key(
-                master_key.as_ref(),
-                verify.id,
-                &verify.vault_key_enc,
-            )
-            .map_err(|_| CoreError::InvalidArgument("invalid password".to_string()))?;
+            let verify = vaults.first().expect("vaults not empty");
+            vault_crypto::decrypt_vault_key(master_key.as_ref(), verify.id, &verify.vault_key_enc)
+                .map_err(|_| CoreError::InvalidArgument("invalid password".to_string()))?;
             let item_repo = LocalItemRepo::new(&self.pool);
             let mut selected = vaults
                 .iter()
@@ -339,8 +330,8 @@ impl CoreFacade {
         if self.master_key.lock().expect("lock poisoned").is_none() {
             return Err(CoreError::Locked);
         }
-        let vault_id =
-            Uuid::parse_str(&id).map_err(|_| CoreError::InvalidArgument("invalid vault id".to_string()))?;
+        let vault_id = Uuid::parse_str(&id)
+            .map_err(|_| CoreError::InvalidArgument("invalid vault id".to_string()))?;
         let repo = LocalVaultRepo::new(&self.pool);
         let vaults = self
             .runtime
@@ -363,11 +354,8 @@ impl CoreFacade {
             cursor: page.cursor,
             include_deleted: filter.include_deleted,
         };
-        let result = self.runtime_block_on(services.list_items(
-            self.storage_id(),
-            vault_id,
-            params,
-        ))?;
+        let result =
+            self.runtime_block_on(services.list_items(self.storage_id(), vault_id, params))?;
         Ok(ItemPage {
             items: result
                 .items
@@ -521,13 +509,17 @@ impl CoreFacade {
 
     pub fn initialize_master_password(&self, password: String) -> CoreResult<VaultStatus> {
         if password.len() < 8 {
-            return Err(CoreError::InvalidArgument("password must be at least 8 characters".to_string()));
+            return Err(CoreError::InvalidArgument(
+                "password must be at least 8 characters".to_string(),
+            ));
         }
 
         // Check if already initialized
         let status = self.app_status()?;
         if status.initialized {
-            return Err(CoreError::InvalidArgument("vault already initialized".to_string()));
+            return Err(CoreError::InvalidArgument(
+                "vault already initialized".to_string(),
+            ));
         }
 
         // Derive master key from password
@@ -580,7 +572,11 @@ impl CoreFacade {
         let state = ClientState::new(self.pool.clone(), root);
         let response = self
             .runtime
-            .block_on(zann_client::sync::remote_sync(storage_id, &state, master_key.as_ref()))
+            .block_on(zann_client::sync::remote_sync(
+                storage_id,
+                &state,
+                master_key.as_ref(),
+            ))
             .map_err(CoreError::Service)?;
         if response.ok {
             Ok(())
@@ -597,8 +593,7 @@ impl CoreFacade {
 
 #[uniffi::export]
 pub fn create_core(db_url: String) -> CoreResult<Arc<CoreFacade>> {
-    let runtime =
-        Runtime::new().map_err(|err| CoreError::InvalidArgument(err.to_string()))?;
+    let runtime = Runtime::new().map_err(|err| CoreError::InvalidArgument(err.to_string()))?;
     let pool = runtime
         .block_on(connect_sqlite_with_max(&db_url, 5))
         .map_err(|err| CoreError::Service(err.to_string()))?;
@@ -683,17 +678,13 @@ fn load_or_create_identity_config(db_url: &str) -> CoreResult<IdentityConfig> {
         if debug_master {
             eprintln!(
                 "[MASTER-DEBUG] identity_loaded salt_fp={}",
-                identity
-                    .salt_fingerprint
-                    .as_deref()
-                    .unwrap_or("none")
+                identity.salt_fingerprint.as_deref().unwrap_or("none")
             );
         }
         return Ok(identity);
     }
 
-    std::fs::create_dir_all(&root)
-        .map_err(|err| CoreError::Service(err.to_string()))?;
+    std::fs::create_dir_all(&root).map_err(|err| CoreError::Service(err.to_string()))?;
     let salt = SecretKey::generate();
     let salt_b64 = base64::engine::general_purpose::STANDARD.encode(salt.as_bytes());
     let identity = IdentityConfig {
@@ -715,15 +706,15 @@ fn load_or_create_identity_config(db_url: &str) -> CoreResult<IdentityConfig> {
             .unwrap_or_else(|| "none".to_string());
         eprintln!("[MASTER-DEBUG] identity_created salt_fp={}", salt_fp);
     }
-    let identity_value = serde_json::to_value(&identity)
-        .map_err(|err| CoreError::Service(err.to_string()))?;
+    let identity_value =
+        serde_json::to_value(&identity).map_err(|err| CoreError::Service(err.to_string()))?;
     if let Value::Object(map) = &mut config {
         map.insert("identity".to_string(), identity_value);
     } else {
         config = serde_json::json!({ "identity": identity_value });
     }
-    let json = serde_json::to_string_pretty(&config)
-        .map_err(|err| CoreError::Service(err.to_string()))?;
+    let json =
+        serde_json::to_string_pretty(&config).map_err(|err| CoreError::Service(err.to_string()))?;
     std::fs::write(&path, json).map_err(|err| CoreError::Service(err.to_string()))?;
     Ok(identity)
 }

--- a/crates/zann-ffi/src/lib.rs
+++ b/crates/zann-ffi/src/lib.rs
@@ -66,6 +66,24 @@ pub struct ItemSummary {
     pub deleted: bool,
 }
 
+impl zann_ui_core::ItemLike for ItemSummary {
+    fn title(&self) -> &str {
+        &self.title
+    }
+
+    fn type_id(&self) -> &str {
+        &self.type_id
+    }
+
+    fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn is_deleted(&self) -> bool {
+        self.deleted
+    }
+}
+
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct ItemCountsFfi {
     pub all: u64,
@@ -77,6 +95,20 @@ pub struct ItemCountsFfi {
 pub struct ItemTypeCount {
     pub type_id: String,
     pub count: u64,
+}
+
+impl From<&ItemCountsFfi> for zann_ui_core::ItemCounts {
+    fn from(counts: &ItemCountsFfi) -> Self {
+        Self {
+            all: counts.all,
+            trash: counts.trash,
+            by_type: counts
+                .by_type
+                .iter()
+                .map(|entry| (entry.type_id.clone(), entry.count))
+                .collect(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, uniffi::Record)]

--- a/crates/zann-ui-core/Cargo.toml
+++ b/crates/zann-ui-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "zann-ui-core"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+data-encoding = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+totp-rs = "5"

--- a/crates/zann-ui-core/Cargo.toml
+++ b/crates/zann-ui-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "zann-ui-core"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT"
 
 [dependencies]
 data-encoding = "2"

--- a/crates/zann-ui-core/src/categories.rs
+++ b/crates/zann-ui-core/src/categories.rs
@@ -1,0 +1,283 @@
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+use crate::counts::ItemCounts;
+use crate::item::ItemLike;
+
+/// The navigation schema shared by every client, embedded at compile time.
+pub const UI_CATEGORIES_SCHEMA: &str = include_str!("../../../schemas/ui_categories.json");
+
+/// Whether the categories are rendered for a personal or a shared vault.
+///
+/// The schema uses it twice: to hide categories scoped to one kind of vault,
+/// and to pick a different label (trash is "Shared trash" in a shared vault).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VaultScope {
+    #[default]
+    Personal,
+    Shared,
+}
+
+impl VaultScope {
+    fn as_str(self) -> &'static str {
+        match self {
+            VaultScope::Personal => "personal",
+            VaultScope::Shared => "shared",
+        }
+    }
+
+    fn allows(self, declared: Option<&str>) -> bool {
+        match declared {
+            None | Some("both") => true,
+            Some(scope) => scope == self.as_str(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CategoriesSchema {
+    #[serde(default)]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub fallback_category_id: String,
+    #[serde(default)]
+    pub categories: Vec<Category>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Category {
+    pub id: String,
+    #[serde(default)]
+    pub labels: Vec<Label>,
+    #[serde(default)]
+    pub icon: String,
+    #[serde(default)]
+    pub view: Option<String>,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub group: Option<String>,
+    #[serde(default)]
+    pub order: i32,
+    #[serde(default)]
+    pub filter: Option<CategoryFilter>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Label {
+    pub key: String,
+    #[serde(default)]
+    pub when: Option<LabelCondition>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LabelCondition {
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct CategoryFilter {
+    #[serde(default)]
+    pub type_ids: Option<Vec<String>>,
+    #[serde(default)]
+    pub is_deleted: Option<bool>,
+}
+
+/// A category resolved for rendering: label key, icon name and badge count.
+///
+/// The label is an i18n key and the icon a schema-level name; mapping them to
+/// translated text and toolkit icon names stays with the frontend.
+#[derive(Debug, Clone, Serialize)]
+pub struct CategoryView {
+    pub id: String,
+    pub label_key: String,
+    pub icon: String,
+    pub order: i32,
+    pub count: u64,
+    pub filter: Option<CategoryFilter>,
+}
+
+impl Category {
+    /// Trash is the one category whose contents are the deleted items.
+    pub fn is_trash(&self) -> bool {
+        self.view.as_deref() == Some("trash") || self.id == "trash"
+    }
+
+    pub fn visible_in(&self, scope: VaultScope) -> bool {
+        scope.allows(self.scope.as_deref())
+    }
+
+    /// The most specific label key for `scope`, falling back to the
+    /// unconditional one.
+    pub fn label_key(&self, scope: VaultScope) -> &str {
+        self.labels
+            .iter()
+            .find(|label| {
+                label
+                    .when
+                    .as_ref()
+                    .and_then(|when| when.scope.as_deref())
+                    .is_some_and(|declared| declared == scope.as_str())
+            })
+            .or_else(|| self.labels.iter().find(|label| label.when.is_none()))
+            .or_else(|| self.labels.first())
+            .map(|label| label.key.as_str())
+            .unwrap_or("")
+    }
+
+    /// Badge count for this category.
+    pub fn count(&self, counts: &ItemCounts) -> u64 {
+        if self.is_trash() {
+            return counts.trash;
+        }
+        match self.filter.as_ref().and_then(|f| f.type_ids.as_ref()) {
+            // No type restriction means "everything that is not deleted".
+            None => counts.all,
+            Some(type_ids) => counts.sum_types(type_ids),
+        }
+    }
+
+    /// Whether a loaded item belongs to this category.
+    pub fn matches<I: ItemLike + ?Sized>(&self, item: &I) -> bool {
+        if self.is_trash() {
+            return item.is_deleted();
+        }
+        let Some(filter) = self.filter.as_ref() else {
+            return !item.is_deleted();
+        };
+        if let Some(is_deleted) = filter.is_deleted {
+            if is_deleted != item.is_deleted() {
+                return false;
+            }
+        }
+        if let Some(type_ids) = filter.type_ids.as_ref() {
+            if !type_ids.iter().any(|type_id| type_id == item.type_id()) {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn to_view(&self, counts: &ItemCounts, scope: VaultScope) -> CategoryView {
+        CategoryView {
+            id: self.id.clone(),
+            label_key: self.label_key(scope).to_string(),
+            icon: self.icon.clone(),
+            order: self.order,
+            count: self.count(counts),
+            filter: self.filter.clone(),
+        }
+    }
+}
+
+/// The parsed schema.
+///
+/// The JSON is embedded at compile time and lives in this repository, so a
+/// parse failure is a build bug rather than a runtime condition — `schema_parses`
+/// keeps CI honest about it.
+pub fn schema() -> &'static CategoriesSchema {
+    static SCHEMA: OnceLock<CategoriesSchema> = OnceLock::new();
+    SCHEMA.get_or_init(|| {
+        serde_json::from_str(UI_CATEGORIES_SCHEMA).expect("schemas/ui_categories.json is malformed")
+    })
+}
+
+pub fn category(id: &str) -> Option<&'static Category> {
+    schema().categories.iter().find(|cat| cat.id == id)
+}
+
+/// The category to fall back to when the selected id is unknown.
+pub fn fallback_category() -> Option<&'static Category> {
+    category(&schema().fallback_category_id)
+}
+
+/// Every category visible in `scope`, ordered as the schema declares.
+pub fn category_views(counts: &ItemCounts, scope: VaultScope) -> Vec<CategoryView> {
+    let mut views: Vec<CategoryView> = schema()
+        .categories
+        .iter()
+        .filter(|cat| cat.visible_in(scope))
+        .map(|cat| cat.to_view(counts, scope))
+        .collect();
+    views.sort_by_key(|view| view.order);
+    views
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::item::ItemView;
+
+    fn item(type_id: &str, deleted: bool) -> ItemView {
+        ItemView {
+            title: "Item".to_string(),
+            type_id: type_id.to_string(),
+            path: "root/item".to_string(),
+            deleted,
+        }
+    }
+
+    #[test]
+    fn schema_parses() {
+        let schema = schema();
+        assert!(!schema.categories.is_empty());
+        assert!(category(&schema.fallback_category_id).is_some());
+    }
+
+    #[test]
+    fn views_are_ordered_and_counted() {
+        let counts = ItemCounts::new(12, 4)
+            .with_type("login", 5)
+            .with_type("ssh_key", 2)
+            .with_type("database", 1);
+        let views = category_views(&counts, VaultScope::Personal);
+
+        let orders: Vec<i32> = views.iter().map(|view| view.order).collect();
+        let mut sorted = orders.clone();
+        sorted.sort_unstable();
+        assert_eq!(orders, sorted);
+
+        let by_id = |id: &str| {
+            views
+                .iter()
+                .find(|view| view.id == id)
+                .unwrap_or_else(|| panic!("category {id} missing"))
+        };
+        assert_eq!(by_id("all").count, 12);
+        assert_eq!(by_id("trash").count, 4);
+        assert_eq!(by_id("login").count, 5);
+        assert_eq!(by_id("infra").count, 3);
+    }
+
+    #[test]
+    fn trash_label_depends_on_scope() {
+        let trash = category("trash").expect("trash category");
+        assert_eq!(trash.label_key(VaultScope::Personal), "nav.trash");
+        assert_eq!(trash.label_key(VaultScope::Shared), "items.trashShared");
+    }
+
+    #[test]
+    fn trash_matches_only_deleted_items() {
+        let trash = category("trash").expect("trash category");
+        assert!(trash.matches(&item("login", true)));
+        assert!(!trash.matches(&item("login", false)));
+    }
+
+    #[test]
+    fn typed_category_matches_its_types_only() {
+        let infra = category("infra").expect("infra category");
+        assert!(infra.matches(&item("ssh_key", false)));
+        assert!(!infra.matches(&item("login", false)));
+        assert!(!infra.matches(&item("ssh_key", true)));
+    }
+
+    #[test]
+    fn all_matches_every_live_item() {
+        let all = category("all").expect("all category");
+        assert!(all.matches(&item("login", false)));
+        assert!(all.matches(&item("ssh_key", false)));
+        assert!(!all.matches(&item("login", true)));
+    }
+}

--- a/crates/zann-ui-core/src/counts.rs
+++ b/crates/zann-ui-core/src/counts.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+
+use crate::item::ItemLike;
+
+/// Item counts used to render category badges.
+///
+/// `all` and `trash` are totals reported by the backend (they cover items that
+/// have not been paged in yet), `by_type` maps `type_id` to its count.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ItemCounts {
+    pub all: u64,
+    pub trash: u64,
+    pub by_type: BTreeMap<String, u64>,
+}
+
+impl ItemCounts {
+    pub fn new(all: u64, trash: u64) -> Self {
+        Self {
+            all,
+            trash,
+            by_type: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_type(mut self, type_id: impl Into<String>, count: u64) -> Self {
+        self.by_type.insert(type_id.into(), count);
+        self
+    }
+
+    pub fn of_type(&self, type_id: &str) -> u64 {
+        self.by_type.get(type_id).copied().unwrap_or(0)
+    }
+
+    /// Sum the counts of several types, e.g. every type in a category filter.
+    pub fn sum_types<S: AsRef<str>>(&self, type_ids: &[S]) -> u64 {
+        type_ids
+            .iter()
+            .map(|type_id| self.of_type(type_id.as_ref()))
+            .sum()
+    }
+
+    /// Derive counts from the items currently loaded.
+    ///
+    /// Only correct when the caller holds the full item set; prefer the
+    /// backend-reported counts when paging.
+    pub fn from_items<I: ItemLike>(items: &[I]) -> Self {
+        let mut counts = Self::default();
+        for item in items {
+            if item.is_deleted() {
+                counts.trash += 1;
+                continue;
+            }
+            counts.all += 1;
+            *counts
+                .by_type
+                .entry(item.type_id().to_string())
+                .or_insert(0) += 1;
+        }
+        counts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::item::ItemView;
+
+    fn item(type_id: &str, path: &str, deleted: bool) -> ItemView {
+        ItemView {
+            title: path.to_string(),
+            type_id: type_id.to_string(),
+            path: path.to_string(),
+            deleted,
+        }
+    }
+
+    #[test]
+    fn counts_items_by_type_and_skips_deleted_from_all() {
+        let items = vec![
+            item("login", "a", false),
+            item("login", "b", false),
+            item("note", "c", false),
+            item("card", "d", true),
+        ];
+        let counts = ItemCounts::from_items(&items);
+        assert_eq!(counts.all, 3);
+        assert_eq!(counts.trash, 1);
+        assert_eq!(counts.of_type("login"), 2);
+        assert_eq!(counts.of_type("note"), 1);
+        assert_eq!(counts.of_type("card"), 0);
+    }
+
+    #[test]
+    fn sums_types_of_a_category_filter() {
+        let counts = ItemCounts::new(10, 0)
+            .with_type("ssh_key", 3)
+            .with_type("database", 2);
+        assert_eq!(counts.sum_types(&["ssh_key", "database", "missing"]), 5);
+    }
+}

--- a/crates/zann-ui-core/src/filter.rs
+++ b/crates/zann-ui-core/src/filter.rs
@@ -1,0 +1,196 @@
+use crate::categories::{self, Category};
+use crate::item::ItemLike;
+
+/// Which folder the item list is narrowed to.
+///
+/// Clients spell the "no folder" selection differently in their own state
+/// (`""` in the desktop app, `"__no_folder__"` in QML); they map it onto this
+/// enum rather than the crate guessing a sentinel.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum FolderFilter {
+    #[default]
+    Any,
+    /// Only items that live at the root, with no folder component.
+    WithoutFolder,
+    /// The folder itself and everything below it.
+    Path(String),
+}
+
+impl FolderFilter {
+    pub fn matches(&self, path: &str) -> bool {
+        match self {
+            FolderFilter::Any => true,
+            FolderFilter::WithoutFolder => crate::folders::folder_of(path).is_none(),
+            FolderFilter::Path(selected) => match crate::folders::folder_of(path) {
+                Some(folder) => folder == selected || folder.starts_with(&format!("{selected}/")),
+                None => false,
+            },
+        }
+    }
+}
+
+/// The complete client-side narrowing of the loaded item list.
+#[derive(Debug, Clone, Default)]
+pub struct ItemFilter {
+    /// Category id from the schema; an unknown id falls back to the schema's
+    /// `fallback_category_id`.
+    pub category_id: Option<String>,
+    pub folder: FolderFilter,
+    /// Free-text search over title, path and type. Leave empty when the
+    /// backend already applied the query.
+    pub query: String,
+}
+
+impl ItemFilter {
+    pub fn category(&self) -> Option<&'static Category> {
+        match self.category_id.as_deref() {
+            None => categories::fallback_category(),
+            Some(id) => categories::category(id).or_else(categories::fallback_category),
+        }
+    }
+
+    pub fn matches<I: ItemLike + ?Sized>(&self, item: &I) -> bool {
+        item_matches(item, self.category(), &self.folder) && matches_query(item, &self.query)
+    }
+}
+
+/// Whether an item survives the category and folder narrowing.
+pub fn item_matches<I: ItemLike + ?Sized>(
+    item: &I,
+    category: Option<&Category>,
+    folder: &FolderFilter,
+) -> bool {
+    if let Some(category) = category {
+        if !category.matches(item) {
+            return false;
+        }
+    } else if item.is_deleted() {
+        return false;
+    }
+    folder.matches(item.path())
+}
+
+/// Case-insensitive substring search over the fields shown in the list.
+///
+/// An empty query matches everything.
+pub fn matches_query<I: ItemLike + ?Sized>(item: &I, query: &str) -> bool {
+    let needle = query.trim().to_lowercase();
+    if needle.is_empty() {
+        return true;
+    }
+    [item.title(), item.path(), item.type_id()]
+        .iter()
+        .any(|field| field.to_lowercase().contains(&needle))
+}
+
+/// Positions of the items that pass `filter`, for list views that index back
+/// into the unfiltered item vector.
+pub fn filtered_indices<I: ItemLike>(items: &[I], filter: &ItemFilter) -> Vec<usize> {
+    items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| filter.matches(*item))
+        .map(|(index, _)| index)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::item::ItemView;
+
+    fn item(title: &str, type_id: &str, path: &str, deleted: bool) -> ItemView {
+        ItemView {
+            title: title.to_string(),
+            type_id: type_id.to_string(),
+            path: path.to_string(),
+            deleted,
+        }
+    }
+
+    fn sample() -> Vec<ItemView> {
+        vec![
+            item("AWS root", "login", "work/aws/root", false),
+            item("CI token", "api", "work/aws/ci", false),
+            item("Personal mail", "login", "personal/mail", false),
+            item("Scratch", "note", "scratch", false),
+            item("Old key", "ssh_key", "work/old", true),
+        ]
+    }
+
+    #[test]
+    fn folder_filter_includes_descendants() {
+        let filter = FolderFilter::Path("work".to_string());
+        assert!(filter.matches("work/aws/root"));
+        assert!(filter.matches("work/notes"));
+        assert!(!filter.matches("workshop/notes"));
+        assert!(!filter.matches("scratch"));
+    }
+
+    #[test]
+    fn without_folder_matches_root_items_only() {
+        let filter = FolderFilter::WithoutFolder;
+        assert!(filter.matches("scratch"));
+        assert!(!filter.matches("work/aws/root"));
+    }
+
+    #[test]
+    fn default_filter_hides_deleted_items() {
+        let items = sample();
+        let filter = ItemFilter::default();
+        assert_eq!(filtered_indices(&items, &filter), vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn trash_shows_deleted_items_only() {
+        let items = sample();
+        let filter = ItemFilter {
+            category_id: Some("trash".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(filtered_indices(&items, &filter), vec![4]);
+    }
+
+    #[test]
+    fn category_and_folder_narrow_together() {
+        let items = sample();
+        let filter = ItemFilter {
+            category_id: Some("login".to_string()),
+            folder: FolderFilter::Path("work".to_string()),
+            query: String::new(),
+        };
+        assert_eq!(filtered_indices(&items, &filter), vec![0]);
+    }
+
+    #[test]
+    fn query_searches_title_path_and_type() {
+        let items = sample();
+        let by_title = ItemFilter {
+            query: "aws root".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(filtered_indices(&items, &by_title), vec![0]);
+
+        let by_path = ItemFilter {
+            query: "personal/".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(filtered_indices(&items, &by_path), vec![2]);
+
+        let by_type = ItemFilter {
+            query: "api".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(filtered_indices(&items, &by_type), vec![1]);
+    }
+
+    #[test]
+    fn unknown_category_falls_back_instead_of_emptying_the_list() {
+        let items = sample();
+        let filter = ItemFilter {
+            category_id: Some("does-not-exist".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(filtered_indices(&items, &filter), vec![0, 1, 2, 3]);
+    }
+}

--- a/crates/zann-ui-core/src/folders.rs
+++ b/crates/zann-ui-core/src/folders.rs
@@ -1,0 +1,223 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+use crate::item::ItemLike;
+
+/// One folder in the sidebar tree.
+///
+/// `item_count` is the number of items stored directly in this folder,
+/// `total_count` also counts everything in its descendants.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FolderNode {
+    pub name: String,
+    pub path: String,
+    pub item_count: usize,
+    pub total_count: usize,
+    pub children: Vec<FolderNode>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct FolderTree {
+    /// Items whose path has no folder component, shown as a separate entry.
+    pub items_without_folder: usize,
+    pub tree: Vec<FolderNode>,
+}
+
+impl FolderTree {
+    /// Every folder path in the tree, depth-first, for autocompletion.
+    pub fn flat_paths(&self) -> Vec<String> {
+        fn walk(nodes: &[FolderNode], out: &mut Vec<String>) {
+            for node in nodes {
+                out.push(node.path.clone());
+                walk(&node.children, out);
+            }
+        }
+        let mut paths = Vec::new();
+        walk(&self.tree, &mut paths);
+        paths
+    }
+}
+
+/// The folder part of an item path, i.e. everything before the last segment.
+///
+/// Returns `None` for items that live at the root.
+pub fn folder_of(path: &str) -> Option<&str> {
+    path.rsplit_once('/')
+        .map(|(folder, _)| folder)
+        .filter(|folder| !folder.is_empty())
+}
+
+/// Build the folder tree from the loaded items.
+///
+/// Deleted items are ignored: they are shown under trash, not under their
+/// original folder, so counting them here would inflate every badge.
+pub fn build_folder_tree<I: ItemLike>(items: &[I]) -> FolderTree {
+    let mut items_without_folder = 0usize;
+    let mut direct_counts = BTreeMap::<String, usize>::new();
+    let mut folders = BTreeSet::<String>::new();
+
+    for item in items {
+        if item.is_deleted() {
+            continue;
+        }
+        let Some(folder) = folder_of(item.path()) else {
+            items_without_folder += 1;
+            continue;
+        };
+
+        *direct_counts.entry(folder.to_string()).or_insert(0) += 1;
+
+        // Register the folder and every ancestor, so intermediate levels
+        // without items of their own still show up.
+        let mut ancestor = String::new();
+        for segment in folder.split('/').filter(|segment| !segment.is_empty()) {
+            if !ancestor.is_empty() {
+                ancestor.push('/');
+            }
+            ancestor.push_str(segment);
+            folders.insert(ancestor.clone());
+        }
+    }
+
+    let mut children = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut roots = BTreeSet::<String>::new();
+    for path in &folders {
+        match path.rsplit_once('/') {
+            Some((parent, _)) => {
+                children
+                    .entry(parent.to_string())
+                    .or_default()
+                    .insert(path.clone());
+            }
+            None => {
+                roots.insert(path.clone());
+            }
+        }
+    }
+
+    let tree = roots
+        .iter()
+        .map(|path| build_node(path, &children, &direct_counts))
+        .collect();
+
+    FolderTree {
+        items_without_folder,
+        tree,
+    }
+}
+
+fn build_node(
+    path: &str,
+    children: &BTreeMap<String, BTreeSet<String>>,
+    direct_counts: &BTreeMap<String, usize>,
+) -> FolderNode {
+    let child_nodes: Vec<FolderNode> = children
+        .get(path)
+        .map(|paths| {
+            paths
+                .iter()
+                .map(|child| build_node(child, children, direct_counts))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let item_count = direct_counts.get(path).copied().unwrap_or(0);
+    let total_count = item_count
+        + child_nodes
+            .iter()
+            .map(|child| child.total_count)
+            .sum::<usize>();
+
+    FolderNode {
+        name: path.rsplit('/').next().unwrap_or(path).to_string(),
+        path: path.to_string(),
+        item_count,
+        total_count,
+        children: child_nodes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::item::ItemView;
+
+    fn item(path: &str) -> ItemView {
+        ItemView {
+            title: path.to_string(),
+            type_id: "login".to_string(),
+            path: path.to_string(),
+            deleted: false,
+        }
+    }
+
+    fn deleted(path: &str) -> ItemView {
+        ItemView {
+            deleted: true,
+            ..item(path)
+        }
+    }
+
+    #[test]
+    fn splits_folder_from_item_name() {
+        assert_eq!(folder_of("work/aws/root"), Some("work/aws"));
+        assert_eq!(folder_of("root"), None);
+        assert_eq!(folder_of(""), None);
+        assert_eq!(folder_of("/root"), None);
+    }
+
+    #[test]
+    fn counts_rootless_items_separately() {
+        let items = vec![item("alpha"), item(""), item("work/beta")];
+        let tree = build_folder_tree(&items);
+        assert_eq!(tree.items_without_folder, 2);
+        assert_eq!(tree.tree.len(), 1);
+    }
+
+    #[test]
+    fn rolls_counts_up_through_intermediate_folders() {
+        let items = vec![
+            item("work/aws/root"),
+            item("work/aws/ci"),
+            item("work/gcp/root"),
+            item("work/notes"),
+            item("personal/mail"),
+        ];
+        let tree = build_folder_tree(&items);
+
+        assert_eq!(tree.items_without_folder, 0);
+        let names: Vec<&str> = tree.tree.iter().map(|node| node.name.as_str()).collect();
+        assert_eq!(names, vec!["personal", "work"]);
+
+        let work = &tree.tree[1];
+        assert_eq!(work.item_count, 1);
+        assert_eq!(work.total_count, 4);
+
+        let aws = &work.children[0];
+        assert_eq!(aws.path, "work/aws");
+        assert_eq!(aws.item_count, 2);
+        assert_eq!(aws.total_count, 2);
+    }
+
+    #[test]
+    fn deleted_items_do_not_count_towards_folders() {
+        let items = vec![item("work/a"), deleted("work/b"), deleted("c")];
+        let tree = build_folder_tree(&items);
+        assert_eq!(tree.items_without_folder, 0);
+        assert_eq!(tree.tree[0].total_count, 1);
+    }
+
+    #[test]
+    fn flat_paths_are_depth_first() {
+        let items = vec![item("work/aws/root"), item("personal/mail")];
+        let tree = build_folder_tree(&items);
+        assert_eq!(
+            tree.flat_paths(),
+            vec!["personal", "work", "work/aws"]
+                .into_iter()
+                .map(String::from)
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/zann-ui-core/src/item.rs
+++ b/crates/zann-ui-core/src/item.rs
@@ -1,0 +1,57 @@
+/// The item fields the shared view logic needs.
+///
+/// Every client already has its own item summary type (`zann_ffi::ItemSummary`,
+/// the Tauri `ItemSummary`, ...). Implementing this trait for it avoids copying
+/// items into a crate-local struct just to build a folder tree or run a filter.
+pub trait ItemLike {
+    fn title(&self) -> &str;
+    fn type_id(&self) -> &str;
+    fn path(&self) -> &str;
+    fn is_deleted(&self) -> bool;
+}
+
+/// Owned item view, for callers that have no type of their own to adapt
+/// (tests, ad-hoc conversions).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ItemView {
+    pub title: String,
+    pub type_id: String,
+    pub path: String,
+    pub deleted: bool,
+}
+
+impl ItemLike for ItemView {
+    fn title(&self) -> &str {
+        &self.title
+    }
+
+    fn type_id(&self) -> &str {
+        &self.type_id
+    }
+
+    fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn is_deleted(&self) -> bool {
+        self.deleted
+    }
+}
+
+impl<T: ItemLike> ItemLike for &T {
+    fn title(&self) -> &str {
+        (*self).title()
+    }
+
+    fn type_id(&self) -> &str {
+        (*self).type_id()
+    }
+
+    fn path(&self) -> &str {
+        (*self).path()
+    }
+
+    fn is_deleted(&self) -> bool {
+        (*self).is_deleted()
+    }
+}

--- a/crates/zann-ui-core/src/lib.rs
+++ b/crates/zann-ui-core/src/lib.rs
@@ -1,0 +1,29 @@
+//! UI-facing view logic shared by every zann client.
+//!
+//! This crate holds the presentation rules that used to be duplicated in each
+//! frontend: the navigation categories described by `schemas/ui_categories.json`,
+//! the folder tree derived from item paths, the client-side item filter, TOTP
+//! code generation and server URL normalization.
+//!
+//! It deliberately depends on nothing but `serde` and two leaf crates: no
+//! database, no HTTP, no UI toolkit, no FFI. Callers adapt their own item type
+//! through the [`ItemLike`] trait instead of the crate reaching into theirs.
+
+pub mod categories;
+pub mod counts;
+pub mod filter;
+pub mod folders;
+pub mod item;
+pub mod server_url;
+pub mod totp;
+
+pub use categories::{
+    category, category_views, fallback_category, CategoriesSchema, Category, CategoryFilter,
+    CategoryView, VaultScope,
+};
+pub use counts::ItemCounts;
+pub use filter::{filtered_indices, item_matches, FolderFilter, ItemFilter};
+pub use folders::{build_folder_tree, FolderNode, FolderTree};
+pub use item::{ItemLike, ItemView};
+pub use server_url::normalize_server_url;
+pub use totp::{generate_totp, TotpCode, TotpError, TotpParams};

--- a/crates/zann-ui-core/src/server_url.rs
+++ b/crates/zann-ui-core/src/server_url.rs
@@ -1,0 +1,46 @@
+/// Turn what the user typed in the "connect to server" field into a URL.
+///
+/// Blank input stays blank so callers can report "server URL is required";
+/// anything without a scheme is assumed to be HTTPS.
+pub fn normalize_server_url(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return trimmed.to_string();
+    }
+    format!("https://{trimmed}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blank_input_stays_blank() {
+        assert_eq!(normalize_server_url(""), "");
+        assert_eq!(normalize_server_url("   "), "");
+    }
+
+    #[test]
+    fn keeps_an_explicit_scheme() {
+        assert_eq!(
+            normalize_server_url("http://localhost:8080"),
+            "http://localhost:8080"
+        );
+        assert_eq!(
+            normalize_server_url(" https://zann.example "),
+            "https://zann.example"
+        );
+    }
+
+    #[test]
+    fn defaults_to_https() {
+        assert_eq!(normalize_server_url("zann.example"), "https://zann.example");
+        assert_eq!(
+            normalize_server_url("zann.example:8443/path"),
+            "https://zann.example:8443/path"
+        );
+    }
+}

--- a/crates/zann-ui-core/src/totp.rs
+++ b/crates/zann-ui-core/src/totp.rs
@@ -1,0 +1,189 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use data_encoding::BASE32;
+use serde::Serialize;
+use thiserror::Error;
+use totp_rs::{Algorithm, TOTP};
+
+const DEFAULT_ALGORITHM: &str = "SHA1";
+const DEFAULT_DIGITS: u32 = 6;
+const DEFAULT_PERIOD: u32 = 30;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TotpError {
+    #[error("unsupported otp algorithm")]
+    Algorithm,
+    #[error("unsupported otp digits")]
+    Digits,
+    #[error("invalid otp period")]
+    Period,
+    #[error("invalid otp secret")]
+    Secret,
+    #[error("invalid system time")]
+    SystemTime,
+    #[error("{0}")]
+    Generate(String),
+}
+
+/// TOTP parameters as they come out of an item payload; `None` means "use the
+/// RFC 6238 default".
+#[derive(Debug, Clone, Default)]
+pub struct TotpParams {
+    pub secret: String,
+    pub algorithm: Option<String>,
+    pub digits: Option<u32>,
+    pub period: Option<u32>,
+}
+
+impl TotpParams {
+    pub fn new(secret: impl Into<String>) -> Self {
+        Self {
+            secret: secret.into(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TotpCode {
+    pub code: String,
+    /// Seconds until the current code rolls over.
+    pub remaining_seconds: u32,
+    pub period: u32,
+}
+
+pub fn generate_totp(params: &TotpParams) -> Result<TotpCode, TotpError> {
+    let algorithm = parse_algorithm(params.algorithm.as_deref())?;
+    let digits = parse_digits(params.digits)?;
+    let period = parse_period(params.period)?;
+    let secret = decode_secret(&params.secret)?;
+
+    // `TOTP::new` rejects secrets shorter than 128 bits since totp-rs 5.7.1.
+    // Plenty of services still hand out 80-bit secrets, and refusing to show a
+    // code for a secret the user already holds helps nobody, so the length
+    // check is skipped deliberately.
+    let totp = TOTP::new_unchecked(algorithm, digits as usize, 1, period as u64, secret);
+    let code = totp
+        .generate_current()
+        .map_err(|err| TotpError::Generate(err.to_string()))?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| TotpError::SystemTime)?
+        .as_secs();
+    let remaining_seconds = period as u64 - (now % period as u64);
+
+    Ok(TotpCode {
+        code,
+        remaining_seconds: remaining_seconds as u32,
+        period,
+    })
+}
+
+fn parse_algorithm(value: Option<&str>) -> Result<Algorithm, TotpError> {
+    let value = value.unwrap_or(DEFAULT_ALGORITHM).trim();
+    let normalized = if value.is_empty() {
+        DEFAULT_ALGORITHM.to_string()
+    } else {
+        value.to_uppercase()
+    };
+    match normalized.as_str() {
+        "SHA1" => Ok(Algorithm::SHA1),
+        "SHA256" => Ok(Algorithm::SHA256),
+        "SHA512" => Ok(Algorithm::SHA512),
+        _ => Err(TotpError::Algorithm),
+    }
+}
+
+fn parse_digits(value: Option<u32>) -> Result<u32, TotpError> {
+    match value.unwrap_or(DEFAULT_DIGITS) {
+        digits @ (6 | 8) => Ok(digits),
+        _ => Err(TotpError::Digits),
+    }
+}
+
+fn parse_period(value: Option<u32>) -> Result<u32, TotpError> {
+    match value.unwrap_or(DEFAULT_PERIOD) {
+        0 => Err(TotpError::Period),
+        period => Ok(period),
+    }
+}
+
+fn decode_secret(secret: &str) -> Result<Vec<u8>, TotpError> {
+    let cleaned: String = secret
+        .chars()
+        .filter(|ch| !ch.is_whitespace() && *ch != '-')
+        .collect::<String>()
+        .to_uppercase();
+    BASE32
+        .decode(cleaned.as_bytes())
+        .map_err(|_| TotpError::Secret)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "JBSWY3DPEHPK3PXP";
+
+    #[test]
+    fn generates_code_with_defaults() {
+        let code = generate_totp(&TotpParams::new(SECRET)).expect("totp");
+        assert_eq!(code.code.len(), 6);
+        assert_eq!(code.period, DEFAULT_PERIOD);
+        assert!(code.remaining_seconds > 0);
+        assert!(code.remaining_seconds <= code.period);
+    }
+
+    #[test]
+    fn accepts_formatted_secrets() {
+        let code = generate_totp(&TotpParams::new("jbsw y3dp-ehpk 3pxp")).expect("totp");
+        let reference = generate_totp(&TotpParams::new(SECRET)).expect("totp");
+        assert_eq!(code.code, reference.code);
+    }
+
+    #[test]
+    fn empty_algorithm_falls_back_to_sha1() {
+        let params = TotpParams {
+            algorithm: Some(String::new()),
+            ..TotpParams::new(SECRET)
+        };
+        assert!(generate_totp(&params).is_ok());
+    }
+
+    #[test]
+    fn rejects_unsupported_parameters() {
+        let bad_algorithm = TotpParams {
+            algorithm: Some("MD5".to_string()),
+            ..TotpParams::new(SECRET)
+        };
+        assert_eq!(generate_totp(&bad_algorithm), Err(TotpError::Algorithm));
+
+        let bad_digits = TotpParams {
+            digits: Some(7),
+            ..TotpParams::new(SECRET)
+        };
+        assert_eq!(generate_totp(&bad_digits), Err(TotpError::Digits));
+
+        let bad_period = TotpParams {
+            period: Some(0),
+            ..TotpParams::new(SECRET)
+        };
+        assert_eq!(generate_totp(&bad_period), Err(TotpError::Period));
+
+        let bad_secret = TotpParams::new("not base32!");
+        assert_eq!(generate_totp(&bad_secret), Err(TotpError::Secret));
+    }
+
+    #[test]
+    fn honours_eight_digit_codes() {
+        let params = TotpParams {
+            digits: Some(8),
+            period: Some(60),
+            ..TotpParams::new(SECRET)
+        };
+        let code = generate_totp(&params).expect("totp");
+        assert_eq!(code.code.len(), 8);
+        assert_eq!(code.period, 60);
+    }
+}

--- a/crates/zann-ui-core/tests/json_shape.rs
+++ b/crates/zann-ui-core/tests/json_shape.rs
@@ -1,0 +1,46 @@
+//! The QML frontend reads these structures as JSON, so their field names are
+//! part of the contract with `apps/kde/qml/main.qml`. Renaming a field here
+//! silently breaks the UI, which no compiler catches — these tests do.
+
+use serde_json::Value;
+
+use zann_ui_core::{build_folder_tree, generate_totp, ItemView, TotpParams};
+
+fn item(path: &str) -> ItemView {
+    ItemView {
+        title: path.to_string(),
+        type_id: "login".to_string(),
+        path: path.to_string(),
+        deleted: false,
+    }
+}
+
+#[test]
+fn folder_tree_json_matches_the_qml_contract() {
+    let tree = build_folder_tree(&[item("work/aws/root"), item("scratch")]);
+    let json: Value = serde_json::from_str(&serde_json::to_string(&tree).expect("serialize"))
+        .expect("valid json");
+
+    assert_eq!(json["items_without_folder"], 1);
+
+    let root = &json["tree"][0];
+    assert_eq!(root["name"], "work");
+    assert_eq!(root["path"], "work");
+    assert_eq!(root["item_count"], 0);
+    assert_eq!(root["total_count"], 1);
+
+    let child = &root["children"][0];
+    assert_eq!(child["path"], "work/aws");
+    assert_eq!(child["total_count"], 1);
+}
+
+#[test]
+fn totp_json_matches_the_qml_contract() {
+    let code = generate_totp(&TotpParams::new("JBSWY3DPEHPK3PXP")).expect("totp");
+    let json: Value = serde_json::from_str(&serde_json::to_string(&code).expect("serialize"))
+        .expect("valid json");
+
+    assert!(json["code"].as_str().is_some_and(|code| code.len() == 6));
+    assert_eq!(json["period"], 30);
+    assert!(json["remaining_seconds"].as_u64().is_some());
+}

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,44 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1785820796,
+        "narHash": "sha256-sZXy8mzUMi2cOGulhoW4HWAZB6JhXOAx1x8J4auZFWk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b6916ba032e02122d6ed3064f40cabe937363d43",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,18 +1,66 @@
 {
-  description = "Zann dev shell";
+  description = "Zann";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, rust-overlay }:
     let
       system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
+      pkgsFor = s: import nixpkgs {
+        system = s;
+        overlays = [ (import rust-overlay) ];
+      };
+      pkgs = pkgsFor system;
+      # Без этого cargo протекал из глобального профиля пользователя,
+      # и проект собирался версией, отличной от rust-toolchain.toml.
+      toolchainFor = p: p.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      rustToolchain = toolchainFor pkgs;
+
+      # zann-cli ставится и на десктоп, и на aarch64-хосты, поэтому пакет
+      # собирается под обе архитектуры. devShell остаётся x86_64-only —
+      # он тянет Qt и WebKit, которые на aarch64 никому не нужны.
+      packageSystems = [ "x86_64-linux" "aarch64-linux" ];
+
+      zannCliFor = s: let
+        p = pkgsFor s;
+        toolchain = toolchainFor p;
+        rustPlatform = p.makeRustPlatform {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
+      in
+        rustPlatform.buildRustPackage {
+          pname = "zann-cli";
+          version = "0.1.0";
+          src = self;
+          # Не cargoHash: он требует ручного обновления при каждом изменении
+          # зависимостей. Cargo.lock не содержит git-источников, поэтому
+          # вендоринг выводится из него напрямую.
+          cargoLock.lockFile = ./Cargo.lock;
+          cargoBuildFlags = [ "--bin" "zann" ];
+
+          nativeBuildInputs = [ p.pkg-config ];
+          buildInputs = with p; [
+            openssl
+            dbus
+            libsecret
+          ];
+
+          meta.mainProgram = "zann";
+        };
     in
     {
+      packages = nixpkgs.lib.genAttrs packageSystems (s: rec {
+        zann-cli = zannCliFor s;
+        default = zann-cli;
+      });
+
       devShells.${system}.default = pkgs.mkShell {
         packages = with pkgs; [
+          rustToolchain
           k6
           pkg-config
           openssl


### PR DESCRIPTION
Extracts the view logic that the KDE and desktop clients each reimplemented, bumps Tauri, and packages `zann-cli` in the flake.

## Commits

| | |
|---|---|
| `style(repo): apply cargo fmt` | `cargo fmt --check` was red on main for 15 files in `zann-client`/`zann-cli`/`zann-db`. Formatting only, kept separate so it does not drown the rest. |
| `refactor(repo): extract shared UI logic into zann-ui-core` | New crate: navigation categories from `schemas/ui_categories.json`, folder tree, item filter, TOTP, server URL normalization. Clients adapt their own item type through `ItemLike`. `apps/kde/src/cxxqt.rs` loses 325 lines, `services/totp.rs` goes 96 → 32. |
| `chore(desktop): bump tauri to 2.11.5` | Scoped with `cargo update -p tauri --precise`, so 8 crates move rather than the 304 a bare update touches. |
| `fix(desktop): raise default window width above the minimum` | `width: 1000` sat below `minWidth: 1125`, so the declared default was dead config. |
| `chore(desktop): add typecheck script and vue-tsc` | Nothing checked TypeScript: `build` is a bare `vite build`, which strips types without checking, and `vue-tsc` was not installed. |
| `chore(repo): pin the rust toolchain and package zann-cli in the flake` | The dev shell had no toolchain, so cargo leaked from the global profile. Adds `rust-overlay` and exposes `packages.zann-cli` for x86_64 and aarch64. |

## Bugs found while unifying the duplicated logic

- the KDE folder tree counted deleted items, inflating every badge
- items with an empty path were dropped instead of counted as "no folder"
- trash ignored the schema's shared-vault label variant
- an unknown category id emptied the list instead of falling back
- TOTP now uses `TOTP::new_unchecked`: `TOTP::new` rejects secrets shorter than 128 bits since totp-rs 5.7.1, and plenty of services still issue 80-bit ones

The QML TOTP payload field is renamed `remaining` → `remaining_seconds` to match the desktop app.

## Verification

- `cargo fmt --all --check` clean
- `cargo test` green for every crate this touches (30 new tests in `zann-ui-core`, including a test pinning the JSON field names QML reads)
- `bun run test` 30 tests, `bun run build`, `bun run tauri build` all pass
- `nix build .#zann-cli` builds and the binary reports `zann 0.1.0`
- desktop e2e fails at `Create KV item`, **identically on `48c7627` before these commits** — pre-existing, matches the "E2E is temporarily disabled" stub in the `Justfile`

## Known red, not caused by this branch

`zann-server` does not compile on `origin/main`: 13 errors from the OpenTelemetry bump in #104. Reproduced on a clean checkout of `222aeea`. CI will be red here for that reason until it is fixed separately.

## Follow-ups deliberately left out

- the Vue frontend still keeps TypeScript copies of the category and folder logic, and they disagree with the schema (`identity` folded into notes, `kv`/`api` into infra)
- `bun run typecheck` reports 390 errors, 316 of them in `AppShell.vue` and `AppModals.vue`; wiring it into CI has to wait for that cleanup