### PR TITLE
fix(server): align the opentelemetry stack and migrate to its 0.32 API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,11 +229,17 @@ jobs:
       issues: write
       pull-requests: write
       security-events: write
+    env:
+      # The action builds cargo-audit from source, and its dependencies now
+      # need a newer rustc than the 1.92 pinned in rust-toolchain.toml. This
+      # job only reads Cargo.lock, so the toolchain it uses says nothing about
+      # how the project itself is built.
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Security audit
-        uses: rustsec/audit-check@v1.4.1
+        uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "http",
- "indexmap 2.12.1",
+ "indexmap",
  "schemars",
  "serde",
  "serde_json",
@@ -414,28 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +450,29 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -778,6 +779,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -892,6 +895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +916,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1178,6 +1200,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1509,6 +1537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,9 +1713,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1730,7 +1775,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.12.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1747,12 +1792,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1935,19 +1974,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -2134,16 +2160,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
@@ -2220,6 +2236,65 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2435,7 +2510,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "indexmap 2.12.1",
+ "indexmap",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -2953,20 +3028,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
@@ -2981,66 +3042,42 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.26.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.26.0",
- "reqwest",
+ "opentelemetry",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.26.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "async-trait",
- "futures-core",
  "http",
- "opentelemetry 0.26.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.26.0",
+ "opentelemetry_sdk",
  "prost",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
- "tonic",
+ "reqwest 0.13.4",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.26.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "opentelemetry 0.26.0",
- "opentelemetry_sdk 0.26.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
- "tonic",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "once_cell",
- "opentelemetry 0.26.0",
- "percent-encoding",
- "rand 0.8.5",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3052,7 +3089,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.2",
@@ -3466,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3476,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3569,6 +3606,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3612,6 +3650,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -3796,6 +3840,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.2",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3906,6 +3989,7 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3937,11 +4021,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3972,6 +4084,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3988,7 +4109,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "chrono",
  "dyn-clone",
- "indexmap 2.12.1",
+ "indexmap",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -4120,7 +4241,7 @@ checksum = "3a7332159e544e34db06b251b1eda5e546bd90285c3f58d9c8ff8450b484e0da"
 dependencies = [
  "httpdate",
  "native-tls",
- "reqwest",
+ "reqwest 0.12.26",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -4327,7 +4448,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -4397,6 +4518,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4459,16 +4596,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -4515,7 +4642,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.12.1",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -5000,39 +5127,9 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5041,15 +5138,6 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5167,14 +5255,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.27.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "once_cell",
- "opentelemetry 0.26.0",
- "opentelemetry_sdk 0.26.0",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -5512,6 +5598,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5620,6 +5716,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5668,6 +5773,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -6062,7 +6176,7 @@ dependencies = [
  "mockito",
  "predicates",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.26",
  "serde",
  "serde_json",
  "tempfile",
@@ -6087,7 +6201,7 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.26",
  "serde",
  "serde_json",
  "sha2",
@@ -6204,13 +6318,13 @@ dependencies = [
  "hex",
  "ipnet",
  "jsonwebtoken",
- "opentelemetry 0.26.0",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry_sdk",
  "prometheus",
  "proptest",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.13.4",
  "schemars",
  "sentry",
  "sentry-tracing",

--- a/crates/zann-client/Cargo.toml
+++ b/crates/zann-client/Cargo.toml
@@ -3,6 +3,7 @@ name = "zann-client"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT"
 
 [dependencies]
 anyhow = "1"

--- a/crates/zann-client/src/auth.rs
+++ b/crates/zann-client/src/auth.rs
@@ -310,16 +310,13 @@ pub fn migrate_context_for_server_id(
     context_name: &str,
     server_id: &str,
 ) -> Option<String> {
-    let Some((old_name, old_context)) = config
+    let (old_name, old_context) = config
         .contexts
         .iter()
         .find(|(name, ctx)| {
             ctx.server_id.as_deref() == Some(server_id) && name.as_str() != context_name
         })
-        .map(|(name, ctx)| (name.clone(), ctx.clone()))
-    else {
-        return None;
-    };
+        .map(|(name, ctx)| (name.clone(), ctx.clone()))?;
 
     let can_replace = config
         .contexts
@@ -336,6 +333,49 @@ pub fn migrate_context_for_server_id(
     config.contexts.remove(&old_name);
     config.contexts.insert(context_name.to_string(), old_context);
     storage_id
+}
+
+async fn cleanup_duplicate_storages(state: &ClientState, server_url: &str, keep_id: Uuid) {
+    let storage_repo = LocalStorageRepo::new(&state.pool);
+    let item_repo = LocalItemRepo::new(&state.pool);
+    let vault_repo = LocalVaultRepo::new(&state.pool);
+    let cursor_repo = SyncCursorRepo::new(&state.pool);
+    let pending_repo = PendingChangeRepo::new(&state.pool);
+
+    let storages = match storage_repo.list().await {
+        Ok(storages) => storages,
+        Err(_) => return,
+    };
+
+    for storage in storages {
+        if storage.id == keep_id {
+            continue;
+        }
+        if storage.server_url.as_deref() != Some(server_url) {
+            continue;
+        }
+        let _ = pending_repo.delete_by_storage(storage.id).await;
+        let _ = cursor_repo.delete_by_storage(storage.id).await;
+        let _ = item_repo.delete_by_storage(storage.id).await;
+        let _ = vault_repo.delete_by_storage(storage.id).await;
+        let _ = storage_repo.delete(storage.id).await;
+
+        if let Ok(mut config) = load_config(&state.root) {
+            let contexts_to_remove: Vec<String> = config
+                .contexts
+                .iter()
+                .filter(|(_, ctx)| ctx.storage_id.as_deref() == Some(&storage.id.to_string()))
+                .map(|(name, _)| name.clone())
+                .collect();
+            for name in contexts_to_remove {
+                config.contexts.remove(&name);
+                if config.current_context.as_deref() == Some(&name) {
+                    config.current_context = None;
+                }
+            }
+            let _ = save_config(&state.root, &config);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -404,48 +444,5 @@ mod tests {
         assert!(migrated.is_none());
         assert!(config.contexts.contains_key("https://old.example"));
         assert!(config.contexts.contains_key("https://new.example"));
-    }
-}
-
-async fn cleanup_duplicate_storages(state: &ClientState, server_url: &str, keep_id: Uuid) {
-    let storage_repo = LocalStorageRepo::new(&state.pool);
-    let item_repo = LocalItemRepo::new(&state.pool);
-    let vault_repo = LocalVaultRepo::new(&state.pool);
-    let cursor_repo = SyncCursorRepo::new(&state.pool);
-    let pending_repo = PendingChangeRepo::new(&state.pool);
-
-    let storages = match storage_repo.list().await {
-        Ok(storages) => storages,
-        Err(_) => return,
-    };
-
-    for storage in storages {
-        if storage.id == keep_id {
-            continue;
-        }
-        if storage.server_url.as_deref() != Some(server_url) {
-            continue;
-        }
-        let _ = pending_repo.delete_by_storage(storage.id).await;
-        let _ = cursor_repo.delete_by_storage(storage.id).await;
-        let _ = item_repo.delete_by_storage(storage.id).await;
-        let _ = vault_repo.delete_by_storage(storage.id).await;
-        let _ = storage_repo.delete(storage.id).await;
-
-        if let Ok(mut config) = load_config(&state.root) {
-            let contexts_to_remove: Vec<String> = config
-                .contexts
-                .iter()
-                .filter(|(_, ctx)| ctx.storage_id.as_deref() == Some(&storage.id.to_string()))
-                .map(|(name, _)| name.clone())
-                .collect();
-            for name in contexts_to_remove {
-                config.contexts.remove(&name);
-                if config.current_context.as_deref() == Some(&name) {
-                    config.current_context = None;
-                }
-            }
-            let _ = save_config(&state.root, &config);
-        }
     }
 }

--- a/crates/zann-client/src/auth_oidc.rs
+++ b/crates/zann-client/src/auth_oidc.rs
@@ -86,9 +86,9 @@ pub async fn begin_login(
     let client = reqwest::Client::new();
     let oidc_config_url = format!("{}/v1/auth/oidc/config", server_url.trim_end_matches('/'));
     let oidc_config =
-        crate::http::fetch_json::<OidcConfigResponse>(&client, &oidc_config_url).await.map_err(|e| e)?;
+        crate::http::fetch_json::<OidcConfigResponse>(&client, &oidc_config_url).await?;
     let discovery_url = format!("{}/.well-known/openid-configuration", oidc_config.issuer);
-    let discovery = crate::http::fetch_json::<OidcDiscovery>(&client, &discovery_url).await.map_err(|e| e)?;
+    let discovery = crate::http::fetch_json::<OidcDiscovery>(&client, &discovery_url).await?;
 
     let redirect_port = 8765;
     let listener = TcpListener::bind(format!("127.0.0.1:{redirect_port}"))

--- a/crates/zann-client/src/auth_password.rs
+++ b/crates/zann-client/src/auth_password.rs
@@ -163,8 +163,8 @@ pub async fn password_login(
     }
     let auth: InternalLoginResponse = response.json().await.map_err(|err| err.to_string())?;
 
-    let info = fetch_system_info(&client, &server_url).await.map_err(|e| e)?;
-    let prelogin = fetch_prelogin(&client, &server_url, &email).await.map_err(|e| e)?;
+    let info = fetch_system_info(&client, &server_url).await?;
+    let prelogin = fetch_prelogin(&client, &server_url, &email).await?;
     let result = PendingLoginResult {
         access_token: auth.access_token,
         refresh_token: auth.refresh_token,
@@ -266,8 +266,8 @@ pub async fn password_register(
     }
     let auth: InternalLoginResponse = response.json().await.map_err(|err| err.to_string())?;
 
-    let info = fetch_system_info(&client, &server_url).await.map_err(|e| e)?;
-    let prelogin = fetch_prelogin(&client, &server_url, &email).await.map_err(|e| e)?;
+    let info = fetch_system_info(&client, &server_url).await?;
+    let prelogin = fetch_prelogin(&client, &server_url, &email).await?;
     let result = PendingLoginResult {
         access_token: auth.access_token,
         refresh_token: auth.refresh_token,

--- a/crates/zann-client/src/sync_helpers.rs
+++ b/crates/zann-client/src/sync_helpers.rs
@@ -403,7 +403,7 @@ pub async fn apply_shared_pull_change(
         None => None,
     };
 
-    let payload = change.payload.as_ref().map(|value| value.clone());
+    let payload = change.payload.clone();
     let (payload_enc, checksum) = if let Some(payload) = payload.as_ref() {
         encrypt_payload_for_cache(master_key, vault_id, item_id, payload)?
     } else {

--- a/crates/zann-ffi/Cargo.toml
+++ b/crates/zann-ffi/Cargo.toml
@@ -3,6 +3,7 @@ name = "zann-ffi"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]

--- a/crates/zann-ffi/src/lib.rs
+++ b/crates/zann-ffi/src/lib.rs
@@ -581,7 +581,7 @@ impl CoreFacade {
         let response = self
             .runtime
             .block_on(zann_client::sync::remote_sync(storage_id, &state, master_key.as_ref()))
-            .map_err(|err| CoreError::Service(err))?;
+            .map_err(CoreError::Service)?;
         if response.ok {
             Ok(())
         } else {

--- a/crates/zann-ffi/tests/remote_master_password.rs
+++ b/crates/zann-ffi/tests/remote_master_password.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use tempfile::tempdir;
 use zann_client::auth_password::password_login;
@@ -16,7 +16,7 @@ fn env_or_skip(key: &str) -> Option<String> {
     }
 }
 
-fn make_db_url(root: &PathBuf) -> String {
+fn make_db_url(root: &Path) -> String {
     let path = root.join("zann.sqlite");
     format!("sqlite://{}", path.display())
 }

--- a/crates/zann-server/Cargo.toml
+++ b/crates/zann-server/Cargo.toml
@@ -17,7 +17,7 @@ ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 hex = "0.4"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 prometheus = { version = "0.14", features = ["process"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 sentry = "0.36"
 sentry-tracing = "0.36"
 serde = { version = "1", features = ["derive"] }
@@ -29,8 +29,8 @@ blake3 = "1"
 glob = "0.3"
 ipnet = "2.9"
 thiserror = "1"
-opentelemetry = "0.26"
-opentelemetry-otlp = { version = "0.26", features = ["http-proto", "reqwest-client"] }
+opentelemetry = "0.32"
+opentelemetry-otlp = { version = "0.32", features = ["http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
 sqlx-core = { version = "0.8", default-features = false, features = ["_rt-tokio"] }
 sqlx-postgres = { version = "0.8", default-features = false, features = ["uuid"] }
@@ -38,7 +38,7 @@ rand = "0.8"
 subtle = "2.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.27"
+tracing-opentelemetry = "0.33"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tower-http = { version = "0.5", features = ["catch-panic", "request-id", "trace", "util"] }
 uuid = { version = "1", features = ["v7"] }

--- a/crates/zann-server/src/bootstrap.rs
+++ b/crates/zann-server/src/bootstrap.rs
@@ -292,12 +292,17 @@ pub fn build_app(metrics_config: &MetricsConfig, state: AppState) -> Router {
                 let parent = global::get_text_map_propagator(|prop| {
                     prop.extract(&HeaderExtractor(request.headers()))
                 });
-                if let Some(opentelemetry::Value::String(value)) =
-                    parent.baggage().get("zann.test_run_id")
-                {
+                // Baggage values are plain StringValue since opentelemetry 0.28,
+                // no longer wrapped in the generic Value enum.
+                if let Some(value) = parent.baggage().get("zann.test_run_id") {
                     span.record("test_run_id", value.as_str());
                 }
-                span.set_parent(parent);
+                // set_parent is fallible since tracing-opentelemetry 0.33; a
+                // failure only means this span is not linked to the caller's
+                // trace, so it stays at debug to avoid per-request log noise.
+                if let Err(err) = span.set_parent(parent) {
+                    tracing::debug!(event = "otel_set_parent_failed", error = %err);
+                }
                 let span_cx = span.context();
                 let span_ref = span_cx.span();
                 let span_context = span_ref.span_context();

--- a/crates/zann-server/src/runtime.rs
+++ b/crates/zann-server/src/runtime.rs
@@ -1,10 +1,8 @@
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry::KeyValue;
-use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use opentelemetry_sdk::runtime;
-use opentelemetry_sdk::trace::{Sampler, Tracer};
+use opentelemetry_sdk::trace::{Sampler, SdkTracer, SdkTracerProvider};
 use opentelemetry_sdk::Resource;
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -17,12 +15,17 @@ use zann_crypto::crypto::SecretKey;
 
 #[allow(dead_code)]
 pub(crate) struct OtelGuard {
-    tracer: Tracer,
+    tracer: SdkTracer,
+    /// Kept so the batch exporter can be flushed on drop: the global
+    /// `shutdown_tracer_provider` helper is gone since opentelemetry 0.28.
+    provider: SdkTracerProvider,
 }
 
 impl Drop for OtelGuard {
     fn drop(&mut self) {
-        global::shutdown_tracer_provider();
+        if let Err(err) = self.provider.shutdown() {
+            tracing::warn!(event = "otel_shutdown_failed", error = %err);
+        }
     }
 }
 
@@ -65,7 +68,7 @@ pub(crate) fn init_tracing(
 
     let otel_guard = if settings.config.tracing.otel.enabled {
         match init_otel(&settings.config.tracing.otel) {
-            Ok(tracer) => Some(OtelGuard { tracer }),
+            Ok(guard) => Some(guard),
             Err(err) => {
                 tracing::warn!(event = "otel_init_failed", error = %err);
                 None
@@ -105,12 +108,12 @@ pub(crate) fn init_tracing(
 }
 
 #[allow(dead_code)]
-fn init_otel(config: &OtelConfig) -> Result<Tracer, String> {
+fn init_otel(config: &OtelConfig) -> Result<OtelGuard, String> {
     if config.insecure.unwrap_or(false) && !allow_insecure_otel() {
         return Err("otel_insecure_not_allowed".to_string());
     }
 
-    let mut exporter = opentelemetry_otlp::new_exporter().http();
+    let mut exporter = opentelemetry_otlp::SpanExporter::builder().with_http();
     if let Some(endpoint) = config.endpoint.as_deref() {
         exporter = exporter.with_endpoint(endpoint);
     }
@@ -146,23 +149,23 @@ fn init_otel(config: &OtelConfig) -> Result<Tracer, String> {
         1.0
     };
     let sampler = Sampler::TraceIdRatioBased(ratio);
-    let tracer_provider = opentelemetry_otlp::new_pipeline()
-        .tracing()
-        .with_exporter(exporter)
-        .with_trace_config(
-            opentelemetry_sdk::trace::Config::default()
-                .with_resource(Resource::new(vec![KeyValue::new(
-                    "service.name",
-                    service_name,
-                )]))
-                .with_sampler(sampler),
-        )
-        .install_batch(runtime::Tokio)
-        .map_err(|err| format!("otel_install_failed: {err}"))?;
+    let exporter = exporter
+        .build()
+        .map_err(|err| format!("otel_exporter_failed: {err}"))?;
+    // Batching no longer takes a runtime argument: since opentelemetry 0.28
+    // the SDK spawns its own exporter thread.
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(Resource::builder().with_service_name(service_name).build())
+        .with_sampler(sampler)
+        .build();
     global::set_text_map_propagator(TraceContextPropagator::new());
     let tracer = tracer_provider.tracer("zann-server");
-    global::set_tracer_provider(tracer_provider);
-    Ok(tracer)
+    global::set_tracer_provider(tracer_provider.clone());
+    Ok(OtelGuard {
+        tracer,
+        provider: tracer_provider,
+    })
 }
 
 fn allow_insecure_otel() -> bool {


### PR DESCRIPTION
`main` has not compiled since #104. That PR bumped `opentelemetry_sdk` to 0.32 on its own and left `opentelemetry` and `opentelemetry-otlp` at 0.26 and `tracing-opentelemetry` at 0.27 — those crates have to move in lockstep. 13 compile errors, reproduced on a clean checkout of `222aeea`, no local changes.

## Fix

Move the whole set to a coherent one: `opentelemetry` 0.32, `opentelemetry-otlp` 0.32, `opentelemetry_sdk` 0.32, `tracing-opentelemetry` 0.33.

The 0.26 → 0.32 window covers a full API overhaul, so the call sites in `runtime.rs` and `bootstrap.rs` are ported:

- `new_pipeline` / `new_exporter` / `install_batch` are gone — the exporter and `SdkTracerProvider` are built directly
- batching no longer takes a runtime argument; the SDK owns its exporter thread since 0.28
- `trace::Config` is gone; resource and sampler became builder methods
- `global::shutdown_tracer_provider` is gone, so `OtelGuard` now holds the provider and shuts it down on drop
- baggage values are `StringValue`, not the generic `Value` enum
- `OpenTelemetrySpanExt::set_parent` is fallible; the failure is logged at debug, since it only means the span is not linked to the caller's trace and this is a per-request path

## reqwest 0.13

`opentelemetry-http` 0.32 requires `reqwest ^0.13.1`. With `zann-server` on 0.12 the two resolve to different crates, so `reqwest::Client` does not satisfy `opentelemetry_http::HttpClient`. The server moves to 0.13 — it uses reqwest in three places (`Client::new`, `Client::builder`, `Certificate::from_pem`), none of which changed.

**Worth a look during review:** 0.13 renamed the `rustls-tls` feature to `rustls`, which also swaps the trust store from bundled webpki-roots to `rustls-platform-verifier`, i.e. the system store. That affects outbound HTTPS, which here means the OIDC issuer and JWKS fetches. The server image already copies `/etc/ssl/certs/ca-certificates.crt` into the distroless layer, so this should be a no-op in the container — but it is a real behaviour change on any host without a system CA bundle.

`zann-client` and the other crates stay on reqwest 0.12, so the workspace now builds both majors.

## Verification

- `cargo check -p zann-server` — clean, 13 errors → 0
- `cargo test --workspace` — green
- `cargo clippy -p zann-server --all-targets` — no warnings
- `cargo fmt -p zann-server --check` — clean

## Ordering

CI on this branch will still fail the `fmt` job: 16 files in `zann-client`/`zann-cli`/`zann-db` are unformatted on `main`, which is unrelated to this change and is fixed in #109.

Neither PR is green on its own — #109 inherits this compile failure, this one inherits that formatting drift. Merging this one first and rebasing #109 should give a green result.