### PR TITLE
fix(deps): clear the two patchable RUSTSEC advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,2 +1,20 @@
 [advisories]
-ignore = ["RUSTSEC-2024-0388", "RUSTSEC-2024-0384"]
+ignore = [
+  "RUSTSEC-2024-0388",
+  "RUSTSEC-2024-0384",
+  # RUSTSEC-2023-0071 - Marvin Attack, a timing sidechannel in `rsa` that can
+  # leak a private key. Upstream has no patch; the constant-time rewrite has
+  # been open since 2023, so no version bump clears it.
+  #
+  # `rsa` reaches us through `jsonwebtoken` <- `zann-server`, which only ever
+  # verifies: the sole RSA usage is `Validation::new(Algorithm::RS256)` in
+  # `domains/auth/core/oidc.rs`, checking OIDC tokens against the provider's
+  # public JWKS. There is no `EncodingKey` anywhere in `crates/zann-server/src`,
+  # so the server performs no RSA private-key operation. The attack targets
+  # private-key decryption and signing; public-key verification handles no
+  # secret whose timing could leak.
+  #
+  # Revisit if the server ever signs or decrypts with RSA, or if `jsonwebtoken`
+  # drops the dependency.
+  "RUSTSEC-2023-0071",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ loadtest/loadtest_sa_token
 loadtest/data/loadtest_sa_token
 compose.loadtest.yaml
 .serena
+.playwright-mcp/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -179,7 +179,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -810,7 +810,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -820,7 +831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -991,6 +1002,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1074,7 +1094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1717,11 +1737,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1731,8 +1749,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3356,7 +3377,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3608,15 +3629,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3685,6 +3707,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3720,6 +3753,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4468,7 +4516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4479,7 +4527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 


### PR DESCRIPTION
The security audit job started working again in #110 and immediately reported three advisories. All three predate that PR. Two have patches and are bumped here; the third has none and is put on the ignore list with the reasoning recorded.

## Fixed

**RUSTSEC-2026-0204** — `crossbeam-epoch` 0.9.18 → 0.9.20. Invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`. Reaches us through `metrics-util` ← `metrics-exporter-prometheus`, so it is a real part of the build.

**RUSTSEC-2026-0185 / CVE-2026-25800** — `quinn-proto` 0.11.14 → 0.11.16. Remote memory exhaustion from unbounded out-of-order QUIC stream reassembly, CVSS `AV:N/AC:L/PR:N/UI:N/A:H`. Worth noting that `cargo tree -i quinn-proto --target all` finds no dependent — nothing in the workspace compiles it. It is in `Cargo.lock` because the lockfile resolves optional dependencies too, and `cargo-audit` reads the lockfile rather than the build graph. Bumping it costs nothing and clears the report.

## Ignored: RUSTSEC-2023-0071 in `rsa` 0.9.10

The Marvin Attack, a timing sidechannel that can leak an RSA private key. **There is no patch** — upstream has had this open since 2023 and the constant-time rewrite is still unfinished, so no version bump can clear it.

It does not apply to us. `rsa` arrives via `jsonwebtoken` ← `zann-server`, and the server only ever *verifies*: the sole RSA usage is `Validation::new(Algorithm::RS256)` in `domains/auth/core/oidc.rs`, checking OIDC tokens against the provider's public JWKS. There is no `EncodingKey` anywhere in `crates/zann-server/src`, so the server performs no RSA private-key operation. The Marvin Attack targets private-key decryption and signing; public-key verification handles no secret whose timing could leak.

So the advisory is added to the `ignore` list in `.cargo/audit.toml`, next to the two ids already there, with that reasoning and a revisit condition in a comment: if the server ever signs or decrypts with RSA, or if `jsonwebtoken` drops the dependency, the entry comes back out.

## Also here

- Rebased onto `main`. The `Cargo.lock` conflict was resolved by taking `main`'s lockfile and re-running `cargo update --precise` for both crates rather than merging by hand — the resulting diff is identical to the original commit. This also picks up the `zann-ffi` formatting fix from #109, which is what the `fmt` job was failing on.
- `chore(repo)`: `.playwright-mcp/` added to `.gitignore`. Playwright MCP drops console/page dumps there on every run.

## Verification

- `cargo fmt --all -- --check` — clean.
- `cargo-audit audit` — exits 0. Six informational warnings remain (`bincode`, `paste` unmaintained; `anyhow`, `event-listener`, `rand` ×2 unsound); they do not fail the job.
