### PR TITLE
fix(core): repair the OIDC listener, sync error reporting and the ffi cdylib

### DIFF
--- a/crates/zann-client/src/auth_oidc.rs
+++ b/crates/zann-client/src/auth_oidc.rs
@@ -158,6 +158,7 @@ pub async fn begin_login(
     );
 
     let state_clone = state.clone();
+    let state_for_cleanup = state.clone();
     let status_tx_listener = status_tx.clone();
     std::thread::spawn(move || {
         if let Err(err) = listen_for_oidc_callback(
@@ -167,6 +168,12 @@ pub async fn begin_login(
             redirect_port,
             status_tx_listener,
         ) {
+            // A login that never completed still holds its verifier, its state
+            // and possibly a session; drop it instead of keeping it for the
+            // lifetime of the process.
+            if let Ok(mut guard) = state_for_cleanup.pending_logins.lock() {
+                guard.remove(&login_id_for_thread);
+            }
             let _ = status_tx.send(oidc_status_error(&login_id_for_thread, err));
         }
     });
@@ -252,29 +259,54 @@ fn listen_for_oidc_callback(
     loop {
         match listener.accept() {
             Ok((mut stream, _)) => {
-                let (code, oauth_state) = parse_oidc_request(&mut stream, port)?;
-                println!("[oidc] callback received for login_id={}", login_id);
-                respond_html(
-                    &mut stream,
-                    "Login complete",
-                    "You can return to the app and close this window.",
-                )?;
-                let status_tx = status_tx.clone();
-                let state = state.clone();
-                let login_id_clone = login_id.clone();
-                std::thread::spawn(move || {
-                    let runtime = tokio::runtime::Runtime::new().expect("runtime");
-                    if let Err(err) = runtime.block_on(complete_oidc_login(
-                        state,
-                        login_id_clone.clone(),
+                // Browsers fire speculative connections (favicon, prefetch, /, the
+                // user navigating to 127.0.0.1:8765 by hand). Treat anything that
+                // is not the OAuth callback as noise and keep listening — losing
+                // the listener to a stray request leaves the real IdP redirect
+                // hitting a closed port.
+                match parse_oidc_request(&mut stream, port) {
+                    Ok(OidcRequest::Callback {
                         code,
-                        oauth_state,
-                        status_tx.clone(),
-                    )) {
-                        let _ = status_tx.send(oidc_status_error(&login_id_clone, err));
+                        state: oauth_state,
+                    }) => {
+                        println!("[oidc] callback received for login_id={}", login_id);
+                        let _ = respond_html(
+                            &mut stream,
+                            "Login complete",
+                            "You can return to the app and close this window.",
+                        );
+                        let status_tx = status_tx.clone();
+                        let state = state.clone();
+                        let login_id_clone = login_id.clone();
+                        std::thread::spawn(move || {
+                            let runtime = tokio::runtime::Runtime::new().expect("runtime");
+                            if let Err(err) = runtime.block_on(complete_oidc_login(
+                                state,
+                                login_id_clone.clone(),
+                                code,
+                                oauth_state,
+                                status_tx.clone(),
+                            )) {
+                                let _ = status_tx.send(oidc_status_error(&login_id_clone, err));
+                            }
+                        });
+                        return Ok(());
                     }
-                });
-                return Ok(());
+                    Ok(OidcRequest::IdpError { error, description }) => {
+                        let detail =
+                            description.unwrap_or_else(|| "Authorization failed.".to_string());
+                        let _ = respond_html(&mut stream, "Login error", &detail);
+                        return Err(format!("authorization error: {error}"));
+                    }
+                    Ok(OidcRequest::Ignored { path }) => {
+                        let _ = respond_not_found(&mut stream);
+                        println!("[oidc] ignoring stray request path={path} login_id={login_id}");
+                    }
+                    Err(err) => {
+                        let _ = respond_not_found(&mut stream);
+                        println!("[oidc] failed to parse stray request: {err}");
+                    }
+                }
             }
             Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
                 if Instant::now() > deadline {
@@ -287,59 +319,86 @@ fn listen_for_oidc_callback(
     }
 }
 
-fn parse_oidc_request(
-    stream: &mut std::net::TcpStream,
-    port: u16,
-) -> Result<(String, String), String> {
+/// What arrived on the redirect listener. Everything that is not the callback
+/// is noise the listener has to survive.
+#[derive(Debug, PartialEq, Eq)]
+enum OidcRequest {
+    Callback {
+        code: String,
+        state: String,
+    },
+    IdpError {
+        error: String,
+        description: Option<String>,
+    },
+    Ignored {
+        path: String,
+    },
+}
+
+fn parse_oidc_request(stream: &mut std::net::TcpStream, port: u16) -> Result<OidcRequest, String> {
     let mut buffer = [0u8; 8192];
     let size = stream.read(&mut buffer).map_err(|err| err.to_string())?;
     if size == 0 {
         return Err("empty request".to_string());
     }
-    let request = String::from_utf8_lossy(&buffer[..size]);
+    parse_oidc_request_line(&String::from_utf8_lossy(&buffer[..size]), port)
+}
+
+fn parse_oidc_request_line(request: &str, port: u16) -> Result<OidcRequest, String> {
     let request_line = request.lines().next().unwrap_or_default();
     let mut parts = request_line.split_whitespace();
     let method = parts.next().unwrap_or_default();
     let path = parts.next().unwrap_or_default();
-    if method != "GET" {
-        respond_html(stream, "Invalid request", "Expected GET request.")?;
-        return Err("invalid request method".to_string());
-    }
-    if !path.starts_with('/') {
-        respond_html(stream, "Invalid request", "Malformed callback URL.")?;
-        return Err("invalid request path".to_string());
+    if method != "GET" || !path.starts_with('/') {
+        return Ok(OidcRequest::Ignored {
+            path: path.to_string(),
+        });
     }
     let full_url = format!("http://127.0.0.1:{port}{path}");
     let url = reqwest::Url::parse(&full_url).map_err(|err| err.to_string())?;
+    if url.path() != "/oidc/callback" {
+        return Ok(OidcRequest::Ignored {
+            path: path.to_string(),
+        });
+    }
     let mut code = None;
     let mut state = None;
     let mut error = None;
     let mut error_description = None;
     for (key, value) in url.query_pairs() {
-        if key == "code" {
-            code = Some(value.to_string());
-        } else if key == "state" {
-            state = Some(value.to_string());
-        } else if key == "error" {
-            error = Some(value.to_string());
-        } else if key == "error_description" {
-            error_description = Some(value.to_string());
+        match key.as_ref() {
+            "code" => code = Some(value.to_string()),
+            "state" => state = Some(value.to_string()),
+            "error" => error = Some(value.to_string()),
+            "error_description" => error_description = Some(value.to_string()),
+            _ => {}
         }
     }
     if let Some(error) = error {
-        let detail = error_description.unwrap_or_else(|| "Authorization failed.".to_string());
-        respond_html(stream, "Login error", &detail).ok();
-        return Err(format!("authorization error: {error}"));
+        return Ok(OidcRequest::IdpError {
+            error,
+            description: error_description,
+        });
     }
-    let code = code.ok_or_else(|| {
-        respond_html(stream, "Login error", "Missing authorization code.").ok();
-        "missing code".to_string()
-    })?;
-    let state = state.ok_or_else(|| {
-        respond_html(stream, "Login error", "Missing state parameter.").ok();
-        "missing state".to_string()
-    })?;
-    Ok((code, state))
+    match (code, state) {
+        (Some(code), Some(state)) => Ok(OidcRequest::Callback { code, state }),
+        _ => Ok(OidcRequest::Ignored {
+            path: path.to_string(),
+        }),
+    }
+}
+
+fn respond_not_found(stream: &mut std::net::TcpStream) -> Result<(), String> {
+    let body = "Not found";
+    let response = format!(
+        "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    stream
+        .write_all(response.as_bytes())
+        .map_err(|err| err.to_string())
 }
 
 fn respond_html(
@@ -473,4 +532,56 @@ async fn complete_oidc_login(
         let _ = status_tx.send(payload);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PORT: u16 = 8765;
+
+    fn parse(request: &str) -> OidcRequest {
+        parse_oidc_request_line(request, PORT).expect("parsed")
+    }
+
+    #[test]
+    fn callback_carries_code_and_state() {
+        assert_eq!(
+            parse("GET /oidc/callback?code=abc&state=xyz HTTP/1.1\r\nHost: 127.0.0.1\r\n"),
+            OidcRequest::Callback {
+                code: "abc".to_string(),
+                state: "xyz".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn idp_error_is_reported_with_its_description() {
+        assert_eq!(
+            parse("GET /oidc/callback?error=access_denied&error_description=Nope HTTP/1.1\r\n"),
+            OidcRequest::IdpError {
+                error: "access_denied".to_string(),
+                description: Some("Nope".to_string()),
+            }
+        );
+    }
+
+    /// The listener used to exit on the first request it accepted, so a browser
+    /// prefetch or a favicon probe closed the port before the real redirect
+    /// arrived.
+    #[test]
+    fn stray_requests_are_ignored_rather_than_fatal() {
+        for request in [
+            "GET /favicon.ico HTTP/1.1\r\n",
+            "GET / HTTP/1.1\r\n",
+            "POST /oidc/callback?code=abc&state=xyz HTTP/1.1\r\n",
+            "GET /oidc/callback?code=abc HTTP/1.1\r\n",
+            "GET /oidc/callback?state=xyz HTTP/1.1\r\n",
+        ] {
+            assert!(
+                matches!(parse(request), OidcRequest::Ignored { .. }),
+                "expected {request:?} to be ignored"
+            );
+        }
+    }
 }

--- a/crates/zann-client/src/sync.rs
+++ b/crates/zann-client/src/sync.rs
@@ -389,7 +389,10 @@ pub async fn remote_sync(
                     .map_err(|err| err.to_string())?;
                 let resp = match ensure_success(resp).await {
                     Ok(response) => response,
-                    Err(_) => break,
+                    Err(err) => {
+                        eprintln!("[sync] shared pull failed for vault {}: {err}", vault.id);
+                        return Ok(ApiResponse::err("sync_shared_pull_failed", &err));
+                    }
                 };
                 let pull = resp
                     .json::<SyncSharedPullResponse>()
@@ -405,7 +408,7 @@ pub async fn remote_sync(
                         master_key,
                     )
                     .await
-                    .is_ok()
+                    .unwrap_or(false)
                     {
                         applied_total += 1;
                     }
@@ -430,7 +433,10 @@ pub async fn remote_sync(
                     .map_err(|err| err.to_string())?;
                 let resp = match ensure_success(resp).await {
                     Ok(response) => response,
-                    Err(_) => break,
+                    Err(err) => {
+                        eprintln!("[sync] pull failed for vault {}: {err}", vault.id);
+                        return Ok(ApiResponse::err("sync_pull_failed", &err));
+                    }
                 };
                 let pull = resp
                     .json::<SyncPullResponse>()
@@ -440,7 +446,7 @@ pub async fn remote_sync(
                 for change in &pull.changes {
                     if apply_pull_change(&item_repo, &history_repo, storage_uuid, vault_id, change)
                         .await
-                        .is_ok()
+                        .unwrap_or(false)
                     {
                         applied_total += 1;
                     }

--- a/crates/zann-client/src/sync_helpers.rs
+++ b/crates/zann-client/src/sync_helpers.rs
@@ -287,11 +287,21 @@ pub async fn apply_pull_change(
     storage_id: Uuid,
     vault_id: Uuid,
     change: &SyncPullChange,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let item_id = Uuid::parse_str(&change.item_id).map_err(|err| err.to_string())?;
+    // A timestamp we cannot read must not be stamped "now": that would make the
+    // change look newer than everything local and win the next comparison.
     let updated_at = match parse_rfc3339(&change.updated_at) {
         Some(value) => value,
-        None => Utc::now(),
+        None => {
+            append_sync_log(&format!(
+                "[pull] invalid updated_at: storage_id={}, item_id={}, value={}",
+                redact_uuid(storage_id),
+                redact_uuid(item_id),
+                change.updated_at
+            ));
+            return Ok(false);
+        }
     };
     let deleted_at = match change.deleted_at.as_ref() {
         Some(value) => parse_rfc3339(value),
@@ -323,7 +333,7 @@ pub async fn apply_pull_change(
                 existing.version,
                 change.seq
             ));
-            return Ok(());
+            return Ok(false);
         }
         existing.path = change.path.clone();
         existing.name = change.name.clone();
@@ -392,7 +402,7 @@ pub async fn apply_pull_change(
 
     apply_history_payloads(history_repo, storage_id, item_id, &history_entries).await?;
 
-    Ok(())
+    Ok(true)
 }
 
 pub async fn apply_shared_pull_change(
@@ -402,11 +412,21 @@ pub async fn apply_shared_pull_change(
     vault_id: Uuid,
     change: &SyncSharedPullChange,
     master_key: &SecretKey,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let item_id = Uuid::parse_str(&change.item_id).map_err(|err| err.to_string())?;
+    // A timestamp we cannot read must not be stamped "now": that would make the
+    // change look newer than everything local and win the next comparison.
     let updated_at = match parse_rfc3339(&change.updated_at) {
         Some(value) => value,
-        None => Utc::now(),
+        None => {
+            append_sync_log(&format!(
+                "[pull] invalid updated_at: storage_id={}, item_id={}, value={}",
+                redact_uuid(storage_id),
+                redact_uuid(item_id),
+                change.updated_at
+            ));
+            return Ok(false);
+        }
     };
     let deleted_at = match change.deleted_at.as_ref() {
         Some(value) => parse_rfc3339(value),
@@ -433,7 +453,7 @@ pub async fn apply_shared_pull_change(
                 existing.version,
                 change.seq
             ));
-            return Ok(());
+            return Ok(false);
         }
         existing.path = change.path.clone();
         existing.name = change.name.clone();
@@ -504,7 +524,7 @@ pub async fn apply_shared_pull_change(
 
     apply_shared_history_payloads(history_repo, storage_id, item_id, &history_entries).await?;
 
-    Ok(())
+    Ok(true)
 }
 
 async fn apply_history_payloads(

--- a/crates/zann-ffi/Cargo.toml
+++ b/crates/zann-ffi/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 license = "MIT"
+
+# `crate-type` belongs to [lib]; under [package] cargo ignores it and never
+# builds the shared library the uniffi bindings load.
+[lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]


### PR DESCRIPTION
## Summary

Three defects found while comparing `crates/zann-client` against the copy of the
same files in `apps/desktop/src-tauri/src/services`. Each one is fixed in
`zann-client`, which is what the CLI-side facade and any new client build on.

**The OIDC callback listener died on stray requests.** It accepted the first
connection and exited regardless of what arrived, so a browser prefetch, a
favicon probe or a manually typed `127.0.0.1:8765` consumed the listener and the
real IdP redirect hit a closed port. The desktop fixed this in #95; the fix never
reached `zann-client`. Request parsing now returns `Callback` / `IdpError` /
`Ignored`, and anything that is not the callback is answered with 404 and
ignored while the listener keeps waiting. A failed login also drops its
`pending_logins` entry instead of holding the verifier, the state and possibly a
session for the lifetime of the process.

**Sync pull failures were swallowed.** Both the personal and the shared pull did
`Err(_) => break`, so a failing request quietly ended the pull and the sync
reported success having fetched nothing. They now return `sync_pull_failed` /
`sync_shared_pull_failed`, as the desktop does.

**An unreadable `updated_at` became "now".** A change whose timestamp failed to
parse was stamped with the current time, which makes it newer than everything
local and win the next version comparison. It is now skipped and logged. The
"applied" counter went along with it: skipping returned `Ok(())` and was counted
as applied, so both pull helpers return `Result<bool>` again.

**`zann-ffi` never built its cdylib.** `crate-type` sat under `[package]`, where
cargo ignores it — the shared library the uniffi bindings load was not produced
at all. Moved to `[lib]`.

## Testing
- [x] cargo test
- [x] cargo fmt
- [x] cargo clippy --all-targets
- [x] `libzann_ffi.so` is produced after the manifest fix

Three unit tests were added for the OIDC request parser, including the case that
caused the original bug (favicon, `/`, POST, callback missing `code` or `state`
are all ignored rather than fatal). `auth_oidc` had no tests on either side of
the fork.

## Risk / Notes

Touches auth and sync. The OIDC change alters control flow in the redirect
listener; it was verified by unit tests on the pure request parser, but the full
browser round trip was not exercised — the mock server in the repository has no
OIDC endpoints.

The `apps/desktop` copies of these files are untouched; they already carry the
correct behaviour. Collapsing that duplication is a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)