### PR TITLE
chore(repo): bump rand within its compatible ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "serde_json",
@@ -2622,7 +2622,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.5",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -2741,7 +2741,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -3119,7 +3119,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.9.5",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -3519,7 +3519,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.10.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3687,9 +3687,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3698,9 +3698,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4235,7 +4235,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "sha2",
  "zbus",
@@ -4339,7 +4339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "653942e6141f16651273159f4b8b1eaeedf37a7554c00cd798953e64b8a9bf72"
 dependencies = [
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.7",
  "sentry-types",
  "serde",
  "serde_json",
@@ -4386,7 +4386,7 @@ checksum = "2d4203359e60724aa05cf2385aaf5d4f147e837185d7dd2b9ccf1ee77f4420c8"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4773,7 +4773,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2",
@@ -6242,7 +6242,7 @@ dependencies = [
  "keyring",
  "mockito",
  "predicates",
- "rand 0.8.5",
+ "rand 0.8.7",
  "reqwest 0.12.26",
  "serde",
  "serde_json",
@@ -6267,7 +6267,7 @@ dependencies = [
  "data-encoding",
  "dirs",
  "ed25519-dalek",
- "rand 0.8.5",
+ "rand 0.8.7",
  "reqwest 0.12.26",
  "serde",
  "serde_json",
@@ -6307,7 +6307,7 @@ dependencies = [
  "chacha20poly1305",
  "hex",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2",
@@ -6391,7 +6391,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prometheus",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.7",
  "reqwest 0.13.4",
  "schemars",
  "sentry",
@@ -6457,7 +6457,7 @@ dependencies = [
  "nix 0.26.4",
  "once_cell",
  "ordered-stream",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_repr",
  "sha1",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.2",
+ "rand 0.9.5",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -3733,7 +3733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3743,7 +3743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -4168,9 +4168,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4179,9 +4179,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4690,7 +4690,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "sha2",
  "zbus 3.15.2",
@@ -7446,7 +7446,7 @@ dependencies = [
  "blake3",
  "chacha20poly1305",
  "hex",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2",
@@ -7490,7 +7490,7 @@ dependencies = [
  "ed25519-dalek",
  "keyring",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.7",
  "reqwest 0.12.26",
  "rfd",
  "serde",
@@ -7561,7 +7561,7 @@ dependencies = [
  "nix 0.26.4",
  "once_cell",
  "ordered-stream",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_repr",
  "sha1",


### PR DESCRIPTION
## Summary

Clears GHSA-cq8v-f236-94qc (`rand` is unsound with a custom logger that itself
calls `rand::rng()`) without touching any code.

The advisory is fixed in **0.8.6**, not in 0.9 or 0.10 — Dependabot's #115
proposes 0.10.2 only because it reaches for the newest version. Two vulnerable
ranges were flagged, `>= 0.7.0, < 0.8.6` and `>= 0.9.0, < 0.9.3`, so both locks
get two bumps inside their existing semver ranges:

- `rand` 0.8.5 → 0.8.7
- `rand` 0.9.2 → 0.9.5

Lockfiles only. No source changes, no API renames.

**Why not 0.10.** Moving to the 0.9+ line is a migration, not a bump.
`ed25519-dalek`, `chacha20poly1305`, `argon2` and `rsa` all bind to
`rand_core` 0.6, so `XChaCha20Poly1305::generate_nonce(&mut OsRng)` and
`SigningKey::generate(&mut OsRng)` stop compiling the moment `rand::rngs::OsRng`
implements the 0.9 traits instead. Doing it properly means sourcing two
different `OsRng`s — one for our own byte generation, one for whatever the
crypto crates demand — across nonce and key generation. That is a deliberate
piece of work, not something to fold into clearing a low-severity advisory.
#115 can be closed once this lands.

**What stays.** One `rand` 0.7.3 alert survives, in the desktop lock only. It
arrives through `tauri-utils` → `kuchikiki`/`dom_query` → `selectors` →
`phf_codegen` 0.8 → `phf_generator` 0.8, a build-time codegen chain inside
Tauri's own tooling; nothing we declare pins it and no newer `phf` is reachable
until Tauri moves `selectors`. It never reaches the shipped binary.

Also worth noting: the conditions the advisory needs — a custom `log` logger
that calls `rand::rng()` and trips a `ThreadRng` reseed from inside itself — do
not exist here. Logging goes through `tracing` and no logger touches `rand`.

## Testing
- [x] cargo test (workspace)
- [x] cargo check --locked (apps/desktop/src-tauri)

## Risk / Notes

Lockfile only. `rand` feeds salt and key generation in `zann-crypto`, PKCE
verifiers in `zann-client`, and token and password generation in `zann-server`;
all of them stay on the 0.8 API they were written against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)