### PR TITLE
feat(cosmic): install as a desktop app with entry, icons and launcher wrapper

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -56,6 +56,52 @@ cosmic-build:
 cosmic-test:
     cd apps/cosmic && cargo test
 
+# Install into ~/.local so the COSMIC launcher can start it like any other app
+cosmic-install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd apps/cosmic && cargo build --release && cd ../..
+    install -Dm755 apps/cosmic/target/release/zann-cosmic "$HOME/.local/libexec/zann-cosmic"
+    # winit dlopens libwayland at startup, so a bare Exec= from the launcher
+    # dies with NoWaylandLib on NixOS, where nothing is in a global lib dir.
+    # Bake in the library path of the shell that built it.
+    {
+      echo '#!/usr/bin/env bash'
+      if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+        echo "export LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\""
+      fi
+      echo 'exec "$HOME/.local/libexec/zann-cosmic" "$@"'
+    } > "$HOME/.local/bin/zann-cosmic"
+    chmod 755 "$HOME/.local/bin/zann-cosmic"
+    # One logo for the whole product, so the icons come from the Tauri app
+    # rather than a second copy of the same PNGs.
+    for pair in 32:32x32 64:64x64 128:128x128 256:128x128@2x 512:icon; do
+      size="${pair%%:*}"; src="${pair##*:}"
+      install -Dm644 "apps/desktop/src-tauri/icons/${src}.png" \
+        "$HOME/.local/share/icons/hicolor/${size}x${size}/apps/com.rlyeh.zann.Cosmic.png"
+    done
+    install -d "$HOME/.local/share/applications"
+    sed "s|^Exec=zann-cosmic$|Exec=$HOME/.local/bin/zann-cosmic|" \
+      apps/cosmic/data/com.rlyeh.zann.Cosmic.desktop \
+      > "$HOME/.local/share/applications/com.rlyeh.zann.Cosmic.desktop"
+    command -v update-desktop-database >/dev/null && \
+      update-desktop-database "$HOME/.local/share/applications" || true
+    command -v gtk-update-icon-cache >/dev/null && \
+      gtk-update-icon-cache -qtf "$HOME/.local/share/icons/hicolor" || true
+    echo "installed: $HOME/.local/bin/zann-cosmic"
+
+cosmic-uninstall:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rm -f "$HOME/.local/bin/zann-cosmic" "$HOME/.local/libexec/zann-cosmic"
+    rm -f "$HOME/.local/share/applications/com.rlyeh.zann.Cosmic.desktop"
+    for size in 32 64 128 256 512; do
+      rm -f "$HOME/.local/share/icons/hicolor/${size}x${size}/apps/com.rlyeh.zann.Cosmic.png"
+    done
+    command -v update-desktop-database >/dev/null && \
+      update-desktop-database "$HOME/.local/share/applications" || true
+    echo "removed"
+
 db-up:
     podman compose up -d db
 

--- a/apps/cosmic/README.md
+++ b/apps/cosmic/README.md
@@ -63,6 +63,39 @@ just cosmic-run
 Optional:
 - `ZANN_DB_URL` overrides the default `sqlite://$HOME/.zann/local.sqlite`.
 
+## Install it as a desktop app
+
+To launch it from the COSMIC launcher instead of a terminal:
+
+```bash
+just cosmic-install     # ~/.local/bin + ~/.local/share/{applications,icons}
+just cosmic-uninstall
+```
+
+That builds the release binary, installs the desktop entry from `data/` with
+`Exec` rewritten to the absolute path, and takes the icons from the Tauri app —
+one logo for the whole product rather than a second copy of the same PNGs.
+
+The binary itself lands in `~/.local/libexec` and `~/.local/bin/zann-cosmic` is
+a wrapper. That is for NixOS: winit `dlopen`s libwayland at startup, and a
+launcher starts `Exec=` with none of the dev shell's environment, so the bare
+binary dies with `NoWaylandLib`. The wrapper carries the `LD_LIBRARY_PATH` of
+the shell that built it — which means it points at store paths, so run
+`just cosmic-install` again after a `nix-collect-garbage`. Packaging it properly
+(`nix build` with `wrapProgram`) is the next step up from this.
+
+Two more things worth knowing:
+
+- The entry's `StartupWMClass` has to equal the app's `APP_ID`
+  (`com.rlyeh.zann.Cosmic`). If they drift apart the window appears without the
+  launcher's name and icon.
+- Launched this way it gets no `ZANN_DB_URL`, so it opens the same
+  `~/.zann/local.sqlite` as the other clients — including running the local
+  migrations against it. That is fine while this is built from the same commit
+  as the client you rely on; it stops being fine the moment you install a build
+  from a branch that is ahead on schema. Point it elsewhere while testing:
+  `ZANN_DB_URL=sqlite:///tmp/zann-demo/local.sqlite zann-cosmic`.
+
 ## Demo vault
 
 To try the PoC without touching a real vault, seed a throwaway one (the

--- a/apps/cosmic/data/com.rlyeh.zann.Cosmic.desktop
+++ b/apps/cosmic/data/com.rlyeh.zann.Cosmic.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Type=Application
+Name=Zann (COSMIC)
+GenericName=Password Manager
+Comment=Browse your zann vault
+# `just cosmic-install` rewrites this to the absolute installed path, so the
+# launcher does not depend on ~/.local/bin being on PATH.
+Exec=zann-cosmic
+Icon=com.rlyeh.zann.Cosmic
+Terminal=false
+Categories=Utility;Security;
+Keywords=password;vault;secret;totp;
+StartupNotify=true
+# Must equal the app's APP_ID, or the compositor shows the window without the
+# launcher's name and icon.
+StartupWMClass=com.rlyeh.zann.Cosmic

--- a/apps/cosmic/src/main.rs
+++ b/apps/cosmic/src/main.rs
@@ -60,7 +60,10 @@ impl cosmic::Application for App {
     type Flags = ();
     type Message = Message;
 
-    const APP_ID: &'static str = "dev.zann.Cosmic";
+    /// Matches `StartupWMClass` in `data/com.rlyeh.zann.Cosmic.desktop`, which
+    /// is how the compositor ties the window to the launcher entry, and shares
+    /// the prefix the Tauri app already uses (`com.rlyeh.zann`).
+    const APP_ID: &'static str = "com.rlyeh.zann.Cosmic";
 
     fn core(&self) -> &Core {
         &self.core


### PR DESCRIPTION
## Summary

Makes the COSMIC client startable from the launcher instead of only from a
terminal, so it can be tested the way it will actually be used.

- `data/com.rlyeh.zann.Cosmic.desktop` — the desktop entry.
- `just cosmic-install` / `just cosmic-uninstall` — build release, install into
  `~/.local`, refresh the desktop and icon caches.
- Icons come from the Tauri app's `icons/` (32 → 512 px) rather than a second
  copy of the same logo; both clients are the same product.
- `APP_ID` moves from `dev.zann.Cosmic` to **`com.rlyeh.zann.Cosmic`**, matching
  the prefix `apps/desktop` already uses (`com.rlyeh.zann`), and the entry's
  `StartupWMClass` is set to the same string — that is what ties the window to
  the launcher entry.

**The part that needed fixing rather than writing.** Installed as a plain
`Exec=`, the app died immediately:

```
Create event loop: Os(OsError { NoWaylandLib })
```

winit `dlopen`s libwayland at startup, and a launcher starts the entry with none
of the dev shell's environment — on NixOS nothing puts that library anywhere the
loader looks. So the binary goes to `~/.local/libexec` and `~/.local/bin` gets a
wrapper carrying the `LD_LIBRARY_PATH` of the shell that built it. Documented in
the README, including the consequence: those are store paths, so reinstall after
`nix-collect-garbage`. The real fix is packaging it with `nix build` and
`wrapProgram`, which is the next step and out of scope here.

## Testing
- [x] `desktop-file-validate` on both the repository file and the installed one
- [x] `just cosmic-install`, then launched `~/.local/bin/zann-cosmic` from a
  clean environment — starts, and the dock shows the app's own icon, which is
  what confirms `StartupWMClass` matches
- [x] cargo fmt, cargo clippy --all-targets (clean), cargo test (6 tests)

## Risk / Notes

Launched from the launcher the app inherits no `ZANN_DB_URL`, so it opens
`~/.zann/local.sqlite` — the same vault the other clients use, and it runs the
local migrations against it. That is fine while this is built from the same
commit as the client you rely on, and stops being fine for a build from a branch
that is ahead on schema. Called out in the README with the override to use while
testing. Giving an unstable channel its own app id and data root is the piece
that has to come with the channel itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)