### PR TITLE
feat(cosmic): package the COSMIC client as a nix derivation

### DIFF
--- a/apps/cosmic/README.md
+++ b/apps/cosmic/README.md
@@ -65,24 +65,34 @@ Optional:
 
 ## Install it as a desktop app
 
-To launch it from the COSMIC launcher instead of a terminal:
+The packaged way, which is what you want unless you are iterating on the code:
+
+```bash
+nix build .#zann-cosmic          # or: nix profile install .#zann-cosmic
+```
+
+The derivation installs the binary, the desktop entry and the icons into the
+same output, so a `nix profile install` puts all three in the profile and the
+launcher picks the app up on its own. Nothing is left in `~/.local`, and the
+library paths are baked in by `wrapProgram` from the derivation's own inputs, so
+it survives `nix-collect-garbage`.
+
+For a quick loop while changing code, the same thing straight into `~/.local`:
 
 ```bash
 just cosmic-install     # ~/.local/bin + ~/.local/share/{applications,icons}
 just cosmic-uninstall
 ```
 
-That builds the release binary, installs the desktop entry from `data/` with
+That one builds the release binary, installs the desktop entry from `data/` with
 `Exec` rewritten to the absolute path, and takes the icons from the Tauri app —
-one logo for the whole product rather than a second copy of the same PNGs.
-
-The binary itself lands in `~/.local/libexec` and `~/.local/bin/zann-cosmic` is
-a wrapper. That is for NixOS: winit `dlopen`s libwayland at startup, and a
-launcher starts `Exec=` with none of the dev shell's environment, so the bare
-binary dies with `NoWaylandLib`. The wrapper carries the `LD_LIBRARY_PATH` of
-the shell that built it — which means it points at store paths, so run
-`just cosmic-install` again after a `nix-collect-garbage`. Packaging it properly
-(`nix build` with `wrapProgram`) is the next step up from this.
+one logo for the whole product rather than a second copy of the same PNGs. The
+binary lands in `~/.local/libexec` and `~/.local/bin/zann-cosmic` is a wrapper,
+because winit `dlopen`s libwayland at startup and a launcher starts `Exec=` with
+none of the dev shell's environment — the bare binary dies with `NoWaylandLib`.
+That wrapper carries the `LD_LIBRARY_PATH` of the shell that built it, so it
+points at store paths: rerun `just cosmic-install` after a
+`nix-collect-garbage`. The Nix package has no such problem.
 
 Two more things worth knowing:
 

--- a/flake.nix
+++ b/flake.nix
@@ -51,11 +51,86 @@
 
           meta.mainProgram = "zann";
         };
+
+      # apps/cosmic живёт вне воркспейса и собирается свежим stable, а не пином
+      # из rust-toolchain.toml: rust-version у libcosmic выше.
+      zannCosmic = let
+        toolchain = pkgs.rust-bin.stable.latest.default;
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
+        # Библиотеки, которые грузятся через dlopen и потому не попадают в
+        # rpath: без них приложение падает на старте с NoWaylandLib.
+        runtimeLibs = with pkgs; [
+          libxkbcommon
+          wayland
+          vulkan-loader
+          libGL
+        ];
+      in
+        rustPlatform.buildRustPackage {
+          pname = "zann-cosmic";
+          version = "0.1.0-unstable-2026-08-05";
+          src = self;
+          cargoRoot = "apps/cosmic";
+          buildAndTestSubdir = "apps/cosmic";
+          # libcosmic держит iced git-подмодулем, а хешированный fetchgit
+          # подмодули не выкачивает — крейты из iced/ тогда не находятся.
+          # Submodules умеет только ветка allowBuiltinFetchGit, она же
+          # избавляет от одиннадцати outputHashes. Цена — fetch на этапе
+          # вычисления вместо content-addressed выборки.
+          cargoLock = {
+            lockFile = ./apps/cosmic/Cargo.lock;
+            allowBuiltinFetchGit = true;
+          };
+
+          # И пример seed_demo_vault, и tests/flows.rs создают записи через
+          # debug_create_kv_item, который в zann-ffi объявлен под
+          # #[cfg(debug_assertions)] и в release не существует. Поэтому пакет
+          # собирает только бинарь и не гоняет тесты — их место в
+          # `just cosmic-test`, где сборка идёт в debug.
+          cargoBuildFlags = [ "--bin" "zann-cosmic" ];
+          doCheck = false;
+
+          nativeBuildInputs = with pkgs; [ pkg-config makeWrapper ];
+          buildInputs = with pkgs; [
+            openssl
+            libxkbcommon
+            wayland
+            expat
+            fontconfig
+            freetype
+          ] ++ runtimeLibs;
+
+          # Иконки лежат у Tauri-приложения: логотип у продукта один.
+          postInstall = ''
+            install -Dm644 apps/cosmic/data/com.rlyeh.zann.Cosmic.desktop \
+              $out/share/applications/com.rlyeh.zann.Cosmic.desktop
+            for pair in 32:32x32 64:64x64 128:128x128 256:128x128@2x 512:icon; do
+              size="''${pair%%:*}"; src="''${pair##*:}"
+              install -Dm644 "apps/desktop/src-tauri/icons/''${src}.png" \
+                "$out/share/icons/hicolor/''${size}x''${size}/apps/com.rlyeh.zann.Cosmic.png"
+            done
+            wrapProgram $out/bin/zann-cosmic \
+              --prefix LD_LIBRARY_PATH : ${nixpkgs.lib.makeLibraryPath runtimeLibs}
+          '';
+
+          meta = {
+            mainProgram = "zann-cosmic";
+            description = "COSMIC-native zann client";
+            license = nixpkgs.lib.licenses.mit;
+            platforms = [ "x86_64-linux" ];
+          };
+        };
     in
     {
       packages = nixpkgs.lib.genAttrs packageSystems (s: rec {
         zann-cli = zannCliFor s;
         default = zann-cli;
+      } // nixpkgs.lib.optionalAttrs (s == system) {
+        # COSMIC-клиент только под x86_64: libcosmic на aarch64 никто не проверял.
+        zann-cosmic = zannCosmic;
       });
 
       devShells.${system} = {


### PR DESCRIPTION
## Summary

`packages.x86_64-linux.zann-cosmic`, so the client can be installed rather than
run out of a checkout:

```bash
nix profile install .#zann-cosmic
```

The output carries the binary, the desktop entry and the icons, so the launcher
picks the app up with no `~/.local` fiddling, and `wrapProgram` bakes in the
`LD_LIBRARY_PATH` for the libraries winit `dlopen`s. That is the same crash
`just cosmic-install` had to work around, except here the paths come from the
derivation's own inputs and survive `nix-collect-garbage`. Version follows the
nixpkgs convention for unreleased snapshots: `0.1.0-unstable-2026-08-05`.

`just cosmic-install` stays for the fast edit-run loop; the README now leads
with the Nix package and explains when each is the right one.

## Three things this ran into, all recorded in comments

**`cargoLock` with `outputHashes` cannot work here.** libcosmic keeps `iced` as
a git submodule, and `importCargoLock`'s hashed `fetchgit` path does not fetch
submodules — the checkout arrives with an empty `iced/` and the build fails on
`Cannot find path for crate 'build_helpers-0.14.0'`. Submodules are only fetched
on the `allowBuiltinFetchGit` branch, which is what the derivation uses. It also
removes the need for eleven `outputHashes` entries, one per git source. The cost
is a fetch at evaluation time instead of a content-addressed one.

**`cargoHash` is not an option right now either.** crates.io has started
answering `403` to generic user agents — verified directly:
`python-requests/2.32.3` → 403, `curl/8.5.0` → 403, a descriptive agent → 302.
nixpkgs' `fetch-cargo-vendor-util` sends the requests default and only retries
5xx, so every `fetchCargoVendor` build fails on this nixpkgs revision. Not our
bug, but it rules the approach out until the input moves.

**The package builds the binary only, with `doCheck = false`.** Both
`examples/seed_demo_vault.rs` and `tests/flows.rs` create items through
`debug_create_kv_item`, which `zann-ffi` gates behind `#[cfg(debug_assertions)]`
— neither compiles in release. Tests keep running through `just cosmic-test`,
which builds in debug. Worth knowing if we ever want the suite to run against a
release artifact: the facade has no release-safe way to create an item.

## Testing
- [x] `nix flake check`
- [x] `nix build .#zann-cosmic` from a clean derivation
- [x] launched `$out/bin/zann-cosmic` with `env -i` (only HOME, WAYLAND_DISPLAY,
  XDG_RUNTIME_DIR) — starts and stays up, which is what the wrapper had to fix
- [x] output contains the entry and all five icon sizes

## Risk / Notes

Only `packages.x86_64-linux` gains an attribute; `zann-cli` and both dev shells
are untouched, and nothing in the workspace build changes. The package is
x86_64-only — libcosmic on aarch64 is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)