### PR TITLE
feat(cosmic): lay the vault out in three resizable columns

### DIFF
--- a/apps/cosmic/README.md
+++ b/apps/cosmic/README.md
@@ -39,6 +39,29 @@ shell acts on. Two rules keep this from eroding:
 - no `Option` for something that always exists once the app is running, which is
   why `Session` is not optional and a missing database is a separate shell state.
 
+## The three columns
+
+The open vault is the same shape as the Tauri app: nav categories, the item
+list, the item detail. Only the first is libcosmic's — it is the standard nav
+bar, drawn by the shell from `vault::State::nav_model`, and the header bar's
+toggle collapses it the way the desktop sidebar collapses.
+
+The other two are the vault screen's own `row`, not libcosmic's context drawer.
+The drawer would have done it — setting `core.window.context_is_overlay = false`
+turns it into a real third column — but its width is computed, and the desktop
+app lets the reader drag the boundary. So the split is ours: a `mouse_area` over
+a divider starts the drag, and a window-wide subscription follows the pointer
+until the button comes back up, because it leaves those few pixels immediately.
+
+The widths in `screens::vault::layout` are the ones from the desktop app's
+`useAppLayout.ts`, so the split lands in the same place in both clients, and the
+window's minimum is the width at which both columns still fit their minimums.
+Only the list carries a width; the detail takes what is left, and stays in place
+with nothing selected so that selecting an item never reflows the list.
+
+The shell is the one that knows how much of the window the nav bar left, so it
+tells the screen through `set_content_width` rather than the screen guessing.
+
 ## Prereqs
 
 libcosmic's `rust-version` is ahead of the workspace pin in
@@ -123,7 +146,7 @@ Both variables are required. The seed creates a real vault, so its master
 password is yours to choose rather than a constant published here.
 
 It writes a few key/value items plus one login with a masked password and a
-one-time code, so the detail drawer has something to hide and to count down.
+one-time code, so the detail column has something to hide and to count down.
 
 ## Connecting without a server
 

--- a/apps/cosmic/examples/seed_demo_vault.rs
+++ b/apps/cosmic/examples/seed_demo_vault.rs
@@ -22,7 +22,7 @@ const DEMO_ITEMS: &[(&str, &str, &str)] = &[
     ("scratch", "note", "nothing to see here"),
 ];
 
-/// A login with a masked password and a one-time code, so the detail drawer has
+/// A login with a masked password and a one-time code, so the detail column has
 /// something to hide and something to count down.
 const DEMO_LOGIN: &str = r#"{
   "v": 1,

--- a/apps/cosmic/src/main.rs
+++ b/apps/cosmic/src/main.rs
@@ -13,6 +13,7 @@
 //! owns its own state and messages and reports back through its `Outcome`.
 
 use cosmic::app::{Core, Settings, Task};
+use cosmic::iced::core::layout::Limits;
 use cosmic::iced::{Size, Subscription};
 use cosmic::prelude::*;
 use cosmic::widget::nav_bar;
@@ -21,7 +22,11 @@ use zann_cosmic::screens::{self, connect, master, vault, welcome, Screen};
 use zann_cosmic::session::Session;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let settings = Settings::default().size(Size::new(1000.0, 700.0));
+    let settings = Settings::default().size(WINDOW_SIZE).size_limits(
+        Limits::NONE
+            .min_width(WINDOW_MIN.width)
+            .min_height(WINDOW_MIN.height),
+    );
     cosmic::app::run::<App>(settings, ())?;
     Ok(())
 }
@@ -34,9 +39,19 @@ enum Shell {
     Ready { session: Session, screen: Screen },
 }
 
+/// What libcosmic reserves for the nav bar: 280px plus the 8px of padding it
+/// puts beside it. The same pair drives its own condensed-layout breakpoint.
+const NAV_WIDTH: f32 = 288.0;
+
+/// Matches the Tauri app's window, whose minimum is the width at which its
+/// three columns still hold their own minimums.
+const WINDOW_SIZE: Size = Size::new(1200.0, 700.0);
+const WINDOW_MIN: Size = Size::new(1125.0, 650.0);
+
 struct App {
     core: Core,
     shell: Shell,
+    window_width: f32,
 }
 
 #[derive(Clone, Debug)]
@@ -90,7 +105,11 @@ impl cosmic::Application for App {
             Err(err) => Shell::Blocked(err),
         };
 
-        let mut app = App { core, shell };
+        let mut app = App {
+            core,
+            shell,
+            window_width: WINDOW_SIZE.width,
+        };
         app.set_header_title("zann".to_string());
         let task = match app.core.main_window_id() {
             Some(id) => app.set_window_title("zann".to_string(), id),
@@ -121,15 +140,17 @@ impl cosmic::Application for App {
         Task::none()
     }
 
-    fn context_drawer(&self) -> Option<cosmic::app::context_drawer::ContextDrawer<'_, Message>> {
-        match &self.shell {
-            Shell::Ready {
-                screen: Screen::Vault(vault),
-                ..
-            } => vault
-                .context_drawer()
-                .map(|drawer| drawer.map(Message::Vault)),
-            _ => None,
+    /// The vault lays its two columns out itself, so it has to be told how much
+    /// of the window the nav bar left it.
+    fn on_window_resize(&mut self, _id: cosmic::iced::window::Id, width: f32, _height: f32) {
+        self.window_width = width;
+        let content_width = self.content_width();
+        if let Shell::Ready {
+            screen: Screen::Vault(vault),
+            ..
+        } = &mut self.shell
+        {
+            vault.set_content_width(content_width);
         }
     }
 
@@ -163,6 +184,7 @@ impl cosmic::Application for App {
         // The screens borrow `self.shell`, so losing the session is recorded
         // here and applied once that borrow ends.
         let mut lost_session = None;
+        let content_width = self.content_width();
 
         let task = {
             let Shell::Ready { session, screen } = &mut self.shell else {
@@ -234,7 +256,9 @@ impl cosmic::Application for App {
                         master::Outcome::None => Task::none(),
                         master::Outcome::Task(task) => lift(task, Message::Master),
                         master::Outcome::Opened { page, sync_error } => {
-                            *screen = Screen::Vault(Box::new(vault::State::new(page, sync_error)));
+                            let mut vault = vault::State::new(page, sync_error);
+                            vault.set_content_width(content_width);
+                            *screen = Screen::Vault(Box::new(vault));
                             Task::none()
                         }
                     }
@@ -248,12 +272,7 @@ impl cosmic::Application for App {
                         vault::Outcome::None => Task::none(),
                         vault::Outcome::Task(task) => lift(task, Message::Vault),
                         vault::Outcome::Copy(value) => cosmic::task::message(Message::Copy(value)),
-                        vault::Outcome::ShowDetail(show) => {
-                            self.core.set_show_context(show);
-                            Task::none()
-                        }
                         vault::Outcome::Locked => {
-                            self.core.set_show_context(false);
                             *screen =
                                 Screen::Master(master::State::new(master::Mode::Unlock, None));
                             Task::none()
@@ -281,6 +300,18 @@ impl cosmic::Application for App {
                 Screen::Master(state) => state.view().map(Message::Master),
                 Screen::Vault(state) => state.view().map(Message::Vault),
             },
+        }
+    }
+}
+
+impl App {
+    /// What is left of the window once the nav bar has taken its share — which
+    /// is nothing when the user has collapsed it from the header bar.
+    fn content_width(&self) -> f32 {
+        if self.core.nav_bar_active() {
+            self.window_width - NAV_WIDTH
+        } else {
+            self.window_width
         }
     }
 }

--- a/apps/cosmic/src/screens/detail.rs
+++ b/apps/cosmic/src/screens/detail.rs
@@ -1,4 +1,4 @@
-//! Item detail: turning a decrypted payload into fields the drawer can show.
+//! Item detail: turning a decrypted payload into fields the column can show.
 //!
 //! Owned by [`super::vault`], which wraps these messages in its own.
 

--- a/apps/cosmic/src/screens/vault.rs
+++ b/apps/cosmic/src/screens/vault.rs
@@ -1,9 +1,13 @@
-//! The open vault: nav categories, the item list, and the detail drawer.
+//! The open vault: nav categories, the item list, and the detail column.
+//!
+//! The nav bar is the shell's (libcosmic draws it from [`State::nav_model`]);
+//! the two columns in here are the same split the desktop app has, down to the
+//! widths in [`layout`], so a reader moving between the clients is not asked to
+//! learn a second shape.
 
 use std::time::Duration;
 
-use cosmic::app::context_drawer::{self, ContextDrawer};
-use cosmic::iced::{Alignment, Length, Subscription, Task};
+use cosmic::iced::{event, mouse, Alignment, Event, Length, Subscription, Task};
 use cosmic::prelude::*;
 use cosmic::widget::nav_bar;
 use cosmic::{theme, widget, Element};
@@ -50,6 +54,17 @@ fn category_icon(schema_icon: &str) -> &'static str {
     }
 }
 
+/// The widths the desktop app's `useAppLayout.ts` uses, so the split lands in
+/// the same place in both clients. The list is the column that carries a width;
+/// the detail takes whatever is left.
+mod layout {
+    pub const LIST_MIN: f32 = 320.0;
+    pub const LIST_MAX: f32 = 560.0;
+    pub const LIST_DEFAULT: f32 = 400.0;
+    pub const DETAIL_MIN: f32 = 560.0;
+    pub const HANDLE: f32 = 5.0;
+}
+
 fn item_icon(type_id: &str) -> &'static str {
     match type_id {
         "login" => "dialog-password-symbolic",
@@ -59,6 +74,14 @@ fn item_icon(type_id: &str) -> &'static str {
         "api" => "network-server-symbolic",
         _ => "view-list-symbolic",
     }
+}
+
+/// A held splitter. Pressing it does not say where the pointer is, so the
+/// origin is recorded on the first move and every later move is a delta from
+/// there — which also means a press that never moves changes nothing.
+struct Drag {
+    origin_x: Option<f32>,
+    origin_width: f32,
 }
 
 pub struct State {
@@ -71,6 +94,12 @@ pub struct State {
     detail: Option<Detail>,
     busy: bool,
     error: Option<String>,
+    /// The width the user dragged the list to. Kept as their intent even while
+    /// a narrow window forces a smaller one, so it returns when the room does.
+    list_width: f32,
+    /// How much room the shell says the two columns have between them.
+    content_width: f32,
+    drag: Option<Drag>,
 }
 
 #[derive(Clone, Debug)]
@@ -85,6 +114,9 @@ pub enum Message {
     CloseDetail,
     Lock,
     Tick,
+    ResizeStart,
+    ResizeMove(f32),
+    ResizeEnd,
 }
 
 pub enum Outcome {
@@ -92,8 +124,6 @@ pub enum Outcome {
     Task(Task<Message>),
     /// The clipboard belongs to the shell.
     Copy(String),
-    /// The drawer opened or closed; the shell owns that part of the window.
-    ShowDetail(bool),
     Locked,
 }
 
@@ -109,6 +139,10 @@ impl State {
             detail: None,
             busy: false,
             error: sync_error.map(|err| format!("sync failed: {err}")),
+            list_width: layout::LIST_DEFAULT,
+            // Enough for the default split until the shell reports the window.
+            content_width: layout::LIST_DEFAULT + layout::HANDLE + layout::DETAIL_MIN,
+            drag: None,
         };
         state.apply_page(page, true);
         state.rebuild_nav();
@@ -117,6 +151,25 @@ impl State {
 
     pub fn nav_model(&self) -> &nav_bar::Model {
         &self.nav
+    }
+
+    /// The shell owns the window, so it is the one that knows how much of it
+    /// the nav bar left for these two columns.
+    pub fn set_content_width(&mut self, width: f32) {
+        self.content_width = width;
+    }
+
+    /// Where the splitter currently sits, held to what the window allows.
+    pub fn list_width(&self) -> f32 {
+        self.clamped_list_width(self.list_width)
+    }
+
+    /// The stored width, held to what the window can actually give it. A window
+    /// too narrow for both minimums keeps the list at its own minimum and lets
+    /// the detail take the squeeze, which is the order the desktop app uses.
+    fn clamped_list_width(&self, width: f32) -> f32 {
+        let room = self.content_width - layout::HANDLE - layout::DETAIL_MIN;
+        width.min(room.min(layout::LIST_MAX)).max(layout::LIST_MIN)
     }
 
     /// The items the current category, folder and search leave visible.
@@ -135,26 +188,32 @@ impl State {
         self.nav.activate(id);
     }
 
-    pub fn context_drawer(&self) -> Option<ContextDrawer<'_, Message>> {
-        let detail = self.detail.as_ref()?;
-        Some(
-            context_drawer::context_drawer(
-                detail.view().map(Message::Detail),
-                Message::CloseDetail,
-            )
-            .title(detail.title.clone()),
-        )
-    }
-
-    /// One-time codes roll over every period, so an open drawer with one needs
-    /// a redraw every second.
     pub fn subscription(&self) -> Subscription<Message> {
-        match self.detail.as_ref() {
-            Some(detail) if detail.has_totp() => {
-                cosmic::iced::time::every(Duration::from_secs(1)).map(|_| Message::Tick)
-            }
-            _ => Subscription::none(),
+        let mut subscriptions = Vec::with_capacity(2);
+
+        // One-time codes roll over every period, so a shown one needs a redraw
+        // every second.
+        if self.detail.as_ref().is_some_and(Detail::has_totp) {
+            subscriptions
+                .push(cosmic::iced::time::every(Duration::from_secs(1)).map(|_| Message::Tick));
         }
+
+        // A splitter has to keep following the pointer after it leaves the few
+        // pixels it was pressed on, so the drag is tracked window-wide and only
+        // while it lasts.
+        if self.drag.is_some() {
+            subscriptions.push(event::listen_with(|event, _, _| match event {
+                Event::Mouse(mouse::Event::CursorMoved { position }) => {
+                    Some(Message::ResizeMove(position.x))
+                }
+                Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                    Some(Message::ResizeEnd)
+                }
+                _ => None,
+            }));
+        }
+
+        Subscription::batch(subscriptions)
     }
 
     pub fn update(&mut self, message: Message, session: &Session) -> Outcome {
@@ -200,10 +259,7 @@ impl State {
                 }));
             }
 
-            Message::Loaded(Ok(detail)) => {
-                self.detail = Some(detail);
-                return Outcome::ShowDetail(true);
-            }
+            Message::Loaded(Ok(detail)) => self.detail = Some(detail),
 
             Message::Loaded(Err(err)) => self.error = Some(err),
 
@@ -215,10 +271,7 @@ impl State {
                 }
             }
 
-            Message::CloseDetail => {
-                self.detail = None;
-                return Outcome::ShowDetail(false);
-            }
+            Message::CloseDetail => self.detail = None,
 
             Message::Lock => {
                 session.lock();
@@ -226,11 +279,78 @@ impl State {
             }
 
             Message::Tick => {}
+
+            Message::ResizeStart => {
+                self.drag = Some(Drag {
+                    origin_x: None,
+                    origin_width: self.list_width,
+                });
+            }
+
+            Message::ResizeMove(x) => {
+                let Some(drag) = self.drag.as_mut() else {
+                    return Outcome::None;
+                };
+                let origin_x = *drag.origin_x.get_or_insert(x);
+                let desired = drag.origin_width + (x - origin_x);
+                self.list_width = self.clamped_list_width(desired);
+            }
+
+            Message::ResizeEnd => self.drag = None,
         }
         Outcome::None
     }
 
     pub fn view(&self) -> Element<'_, Message> {
+        widget::row::with_capacity(3)
+            .push(widget::container(self.list_view()).width(Length::Fixed(self.list_width())))
+            .push(self.handle_view())
+            .push(widget::container(self.detail_view()).width(Length::Fill))
+            .height(Length::Fill)
+            .into()
+    }
+
+    /// The splitter. It is wider than the line it draws so there is something
+    /// to grab; the pointer says so before the press does.
+    fn handle_view(&self) -> Element<'_, Message> {
+        widget::divider::vertical::default()
+            .apply(widget::container)
+            .width(Length::Fixed(layout::HANDLE))
+            .height(Length::Fill)
+            .align_x(Alignment::Center)
+            .apply(widget::mouse_area)
+            .interaction(mouse::Interaction::ResizingHorizontally)
+            .on_press(Message::ResizeStart)
+            .into()
+    }
+
+    /// The column stays in place with nothing selected, the way the desktop
+    /// app's details panel does, so selecting an item does not reflow the list.
+    fn detail_view(&self) -> Element<'_, Message> {
+        let spacing = theme::spacing();
+
+        let Some(detail) = self.detail.as_ref() else {
+            return super::centered(widget::text::body("Select an item to read it."));
+        };
+
+        let header = widget::row::with_capacity(2)
+            .push(widget::text::title4(detail.title.clone()).width(Length::Fill))
+            .push(
+                widget::button::icon(widget::icon::from_name("window-close-symbolic"))
+                    .on_press(Message::CloseDetail),
+            )
+            .spacing(spacing.space_xs)
+            .align_y(Alignment::Center);
+
+        widget::column::with_capacity(2)
+            .push(header)
+            .push(widget::scrollable(detail.view().map(Message::Detail)).height(Length::Fill))
+            .spacing(spacing.space_s)
+            .padding(spacing.space_s)
+            .into()
+    }
+
+    fn list_view(&self) -> Element<'_, Message> {
         let spacing = theme::spacing();
         let visible = self.visible();
 

--- a/apps/cosmic/tests/flows.rs
+++ b/apps/cosmic/tests/flows.rs
@@ -159,7 +159,7 @@ fn vault_filters_the_list_and_forwards_copies() {
     state.update(vault::Message::ClearQuery, &session);
     assert_eq!(state.visible().len(), 2);
 
-    // The clipboard belongs to the shell, so the drawer's copy travels up.
+    // The clipboard belongs to the shell, so the detail's copy travels up.
     let outcome = state.update(
         vault::Message::Detail(zann_cosmic::screens::detail::Message::Copy("s3cret".into())),
         &session,
@@ -170,6 +170,42 @@ fn vault_filters_the_list_and_forwards_copies() {
         state.update(vault::Message::Lock, &session),
         vault::Outcome::Locked
     ));
+}
+
+#[test]
+fn the_splitter_stays_between_the_two_minimums() {
+    let (_dir, session) = vault_with_items();
+    let page = local::items(&session.facade(), None).expect("items");
+    let mut state = vault::State::new(page, None);
+    state.set_content_width(1200.0);
+    assert_eq!(state.list_width(), 400.0);
+
+    // Pressing on its own moves nothing: the first move is what fixes the
+    // origin the rest of the drag is measured from.
+    state.update(vault::Message::ResizeStart, &session);
+    state.update(vault::Message::ResizeMove(700.0), &session);
+    assert_eq!(state.list_width(), 400.0);
+    state.update(vault::Message::ResizeMove(800.0), &session);
+    assert_eq!(state.list_width(), 500.0);
+
+    // Dragging past the maximum stops there instead of banking the overshoot,
+    // so coming back moves the splitter on the first pixel.
+    state.update(vault::Message::ResizeMove(1400.0), &session);
+    assert_eq!(state.list_width(), 560.0);
+    state.update(vault::Message::ResizeMove(760.0), &session);
+    assert_eq!(state.list_width(), 460.0);
+
+    // A window with no room for both minimums squeezes the detail, not the
+    // list — and the width the user asked for survives to be restored.
+    state.set_content_width(800.0);
+    assert_eq!(state.list_width(), 320.0);
+    state.set_content_width(1200.0);
+    assert_eq!(state.list_width(), 460.0);
+
+    // Releasing stops the tracking, so a stray pointer no longer resizes.
+    state.update(vault::Message::ResizeEnd, &session);
+    state.update(vault::Message::ResizeMove(200.0), &session);
+    assert_eq!(state.list_width(), 460.0);
 }
 
 #[test]


### PR DESCRIPTION
The detail was a context drawer sliding in over the list; it is now a column beside it, the shape the desktop app has.

libcosmic's drawer can be made a real third column with `context_is_overlay = false`, but its width is computed and the desktop lets the reader drag the boundary — so the split is ours: a `mouse_area` over a divider starts the drag and a window-wide subscription follows the pointer until the button comes back up.

Widths come from the desktop's `useAppLayout.ts` so the split lands in the same place in both clients, and the window minimum is where both columns still fit.

Verified: `cargo fmt`, `cargo clippy --all-targets --all-features`, `cargo test` (7, one new covering the drag and its clamps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)