### PR TITLE
feat(cosmic): run in the tray and close to it

### DIFF
--- a/apps/cosmic/Cargo.lock
+++ b/apps/cosmic/Cargo.lock
@@ -3370,6 +3370,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksni"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "814b44c24cd2cb236c3b8a41c7f08237b452a8e76ecaa81f1cec40b5b678215b"
+dependencies = [
+ "futures-util",
+ "pastey",
+ "serde",
+ "tokio",
+ "zbus",
+]
+
+[[package]]
 name = "kurbo"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4292,6 +4305,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -7925,6 +7944,7 @@ name = "zann-cosmic"
 version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
+ "ksni",
  "libcosmic",
  "open",
  "reqwest",

--- a/apps/cosmic/Cargo.toml
+++ b/apps/cosmic/Cargo.toml
@@ -15,6 +15,13 @@ path = "src/main.rs"
 
 [dependencies]
 dirs = "5"
+# The tray, over StatusNotifierItem. `blocking` keeps `tray::start` callable
+# from `main` before iced owns the runtime; `tokio` puts its zbus connection on
+# the same runtime libcosmic already brings.
+ksni = { version = "0.3.6", default-features = false, features = [
+  "blocking",
+  "tokio",
+] }
 # libcosmic is not published on crates.io; pin the revision so the PoC builds
 # reproducibly. Default features bring winit + wayland + tokio; `wgpu` puts the
 # renderer on the GPU, like the system COSMIC apps.

--- a/apps/cosmic/README.md
+++ b/apps/cosmic/README.md
@@ -62,6 +62,33 @@ with nothing selected so that selecting an item never reflows the list.
 The shell is the one that knows how much of the window the nav bar left, so it
 tells the screen through `set_content_width` rather than the screen guessing.
 
+## The tray
+
+COSMIC has no tray of its own. The panel's status area is a StatusNotifierItem
+host, so `src/tray.rs` puts an SNI on the session bus with `ksni` and the panel
+picks it up — the icon resolves by name, which is why it is the app id the
+hicolor icons are installed under. Add the "Status area" applet to the panel or
+there is nowhere for it to appear.
+
+The close button then hides instead of closing. Wayland has no way to unmap a
+window and map it back — winit's `set_visible` is a no-op there — so hiding
+destroys the window and showing builds a new one. Nothing is lost with it: all
+the state, including the unlocked `Session`, lives in `App` rather than in the
+window. The process survives with none because libcosmic runs as an iced daemon
+and `Settings::exit_on_close(false)` stops it exiting when the main window goes.
+
+Two paths lead into the same message. The header bar's close button arrives
+through `Application::on_app_exit`, whose returning `Some` is what stops
+libcosmic closing the window itself; a close from the compositor arrives as an
+ordinary `window::Event::CloseRequested` once the window is no longer allowed to
+act on one by itself.
+
+If nothing on the bus will take the icon, `tray::start` says so and the close
+button is left alone — a window with nowhere to go and no way back would leave
+a process the user cannot reach.
+
+The vault stays unlocked in the tray, the way the desktop app leaves it.
+
 ## Prereqs
 
 libcosmic's `rust-version` is ahead of the workspace pin in

--- a/apps/cosmic/src/lib.rs
+++ b/apps/cosmic/src/lib.rs
@@ -10,3 +10,4 @@
 pub mod backend;
 pub mod screens;
 pub mod session;
+pub mod tray;

--- a/apps/cosmic/src/main.rs
+++ b/apps/cosmic/src/main.rs
@@ -14,20 +14,30 @@
 
 use cosmic::app::{Core, Settings, Task};
 use cosmic::iced::core::layout::Limits;
-use cosmic::iced::{Size, Subscription};
+use cosmic::iced::{event, window, Event, Size, Subscription};
 use cosmic::prelude::*;
 use cosmic::widget::nav_bar;
-use cosmic::{executor, Element};
+use cosmic::{executor, Application, Element};
 use zann_cosmic::screens::{self, connect, master, vault, welcome, Screen};
 use zann_cosmic::session::Session;
+use zann_cosmic::tray;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let settings = Settings::default().size(WINDOW_SIZE).size_limits(
-        Limits::NONE
-            .min_width(WINDOW_MIN.width)
-            .min_height(WINDOW_MIN.height),
-    );
-    cosmic::app::run::<App>(settings, ())?;
+    // Held for the whole run: dropping this takes the icon down with it.
+    let has_tray = tray::start(App::APP_ID, "zann");
+
+    let settings = Settings::default()
+        .size(WINDOW_SIZE)
+        .size_limits(
+            Limits::NONE
+                .min_width(WINDOW_MIN.width)
+                .min_height(WINDOW_MIN.height),
+        )
+        // Without a tray the window has nowhere to go and no way back, so the
+        // close button has to keep meaning what it says.
+        .exit_on_close(!has_tray);
+
+    cosmic::app::run::<App>(settings, has_tray)?;
     Ok(())
 }
 
@@ -52,6 +62,12 @@ struct App {
     core: Core,
     shell: Shell,
     window_width: f32,
+    /// Whether there is a tray to hide into. Without one the close button is
+    /// left alone and none of the hiding below ever runs.
+    has_tray: bool,
+    /// Wayland cannot unmap a window and map it back, so hiding destroys it and
+    /// showing builds a new one. This is what says which of the two it is.
+    window_open: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -63,6 +79,12 @@ enum Message {
     /// Effects the shell owns because they leave the app.
     Copy(String),
     OpenUrl(String),
+    Tray(tray::Command),
+    /// The user asked for the window to go away — from the header bar, or from
+    /// the compositor.
+    HideWindow,
+    /// A window is gone, whoever closed it.
+    WindowClosed,
 }
 
 /// Lifts a screen's task into the shell's message type.
@@ -72,7 +94,9 @@ fn lift<M: Send + 'static>(task: cosmic::iced::Task<M>, wrap: fn(M) -> Message) 
 
 impl cosmic::Application for App {
     type Executor = executor::Default;
-    type Flags = ();
+    /// Whether a tray icon went up, which is the one thing about the outside
+    /// world the shell has to be told before it draws anything.
+    type Flags = bool;
     type Message = Message;
 
     /// Matches `StartupWMClass` in `data/com.rlyeh.zann.Cosmic.desktop`, which
@@ -88,7 +112,7 @@ impl cosmic::Application for App {
         &mut self.core
     }
 
-    fn init(core: Core, _flags: Self::Flags) -> (Self, Task<Self::Message>) {
+    fn init(core: Core, has_tray: Self::Flags) -> (Self, Task<Self::Message>) {
         let shell = match Session::open() {
             Ok((session, status)) => {
                 let screen = if status.initialized {
@@ -109,6 +133,8 @@ impl cosmic::Application for App {
             core,
             shell,
             window_width: WINDOW_SIZE.width,
+            has_tray,
+            window_open: true,
         };
         app.set_header_title("zann".to_string());
         let task = match app.core.main_window_id() {
@@ -116,6 +142,20 @@ impl cosmic::Application for App {
             None => Task::none(),
         };
         (app, task)
+    }
+
+    /// The header bar's close button. Returning a message is what stops
+    /// libcosmic from closing the window itself, so the shell gets to decide.
+    fn on_app_exit(&mut self) -> Option<Self::Message> {
+        self.has_tray.then_some(Message::HideWindow)
+    }
+
+    /// Called once a surface is gone. Popups close too, so only the one the
+    /// shell draws into counts.
+    fn on_close_requested(&self, id: window::Id) -> Option<Self::Message> {
+        self.core
+            .main_window_is(id)
+            .then_some(Message::WindowClosed)
     }
 
     /// The nav bar belongs to the vault screen.
@@ -155,7 +195,7 @@ impl cosmic::Application for App {
     }
 
     fn subscription(&self) -> Subscription<Self::Message> {
-        match &self.shell {
+        let screen = match &self.shell {
             Shell::Ready {
                 screen: Screen::Connect(connect),
                 ..
@@ -165,7 +205,21 @@ impl cosmic::Application for App {
                 ..
             } => vault.subscription().map(Message::Vault),
             _ => Subscription::none(),
+        };
+
+        if !self.has_tray {
+            return screen;
         }
+
+        // The header bar's close button arrives through `on_app_exit`, but a
+        // close from the compositor is a plain window event once the window is
+        // no longer allowed to act on one by itself.
+        let close = event::listen_with(|event, _, _| {
+            matches!(event, Event::Window(window::Event::CloseRequested))
+                .then_some(Message::HideWindow)
+        });
+
+        Subscription::batch([screen, close, tray::subscription().map(Message::Tray)])
     }
 
     fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
@@ -175,6 +229,26 @@ impl cosmic::Application for App {
             Message::OpenUrl(url) => {
                 if let Err(err) = open::that_detached(&url) {
                     eprintln!("could not open the browser: {err}");
+                }
+                return Task::none();
+            }
+            Message::HideWindow => return self.hide_window(),
+            Message::WindowClosed => {
+                self.window_open = false;
+                return Task::none();
+            }
+            Message::Tray(tray::Command::Show) => return self.show_window(),
+            Message::Tray(tray::Command::Quit) => return cosmic::iced::exit(),
+            Message::Tray(tray::Command::Lock) => {
+                // Only the open vault holds anything worth locking; the other
+                // screens have nothing to take away.
+                if let Shell::Ready {
+                    session,
+                    screen: screen @ Screen::Vault(_),
+                } = &mut self.shell
+                {
+                    session.lock();
+                    *screen = Screen::Master(master::State::new(master::Mode::Unlock, None));
                 }
                 return Task::none();
             }
@@ -281,7 +355,7 @@ impl cosmic::Application for App {
                 }
 
                 // Handled above, before the session was borrowed.
-                Message::Copy(_) | Message::OpenUrl(_) => Task::none(),
+                _ => Task::none(),
             }
         };
 
@@ -305,6 +379,34 @@ impl cosmic::Application for App {
 }
 
 impl App {
+    /// Into the tray. There is no hiding a window on Wayland — winit says as
+    /// much — so this destroys it. Nothing is lost with it: every bit of state
+    /// the app has, including the open [`Session`], lives in `App`.
+    ///
+    /// The process survives with no windows because libcosmic runs as an iced
+    /// daemon, and `exit_on_close(false)` is what stops it exiting anyway.
+    fn hide_window(&mut self) -> Task<Message> {
+        let Some(id) = self.core.main_window_id().filter(|_| self.window_open) else {
+            return Task::none();
+        };
+        window::close(id)
+    }
+
+    /// Back out of it, into a new window that the shell then treats as its main
+    /// one — set before the task runs, because libcosmic routes anything that
+    /// is not the main window to `view_window`, which this app does not have.
+    fn show_window(&mut self) -> Task<Message> {
+        if let Some(id) = self.core.main_window_id().filter(|_| self.window_open) {
+            return cosmic::iced::window::gain_focus(id);
+        }
+
+        let (id, task) = window::open(window_settings());
+        self.core.set_main_window_id(Some(id));
+        self.window_open = true;
+        let title = self.set_window_title("zann".to_string(), id);
+        Task::batch([task.discard(), title])
+    }
+
     /// What is left of the window once the nav bar has taken its share — which
     /// is nothing when the user has collapsed it from the header bar.
     fn content_width(&self) -> f32 {
@@ -314,6 +416,26 @@ impl App {
             self.window_width
         }
     }
+}
+
+/// The window libcosmic would have opened at startup. It builds these from its
+/// own [`Settings`] and keeps them, so reopening has to say the same things
+/// again — client-side decorations above all, or the second window comes up
+/// with the compositor's title bar bolted onto the app's own.
+fn window_settings() -> window::Settings {
+    let mut settings = window::Settings {
+        size: WINDOW_SIZE,
+        min_size: Some(WINDOW_MIN),
+        decorations: false,
+        transparent: true,
+        resizable: true,
+        resize_border: 8,
+        // The whole point of hiding: closing this one must not end the app.
+        exit_on_close_request: false,
+        ..Default::default()
+    };
+    settings.platform_specific.application_id = App::APP_ID.to_string();
+    settings
 }
 
 fn blocked_view(reason: &str) -> Element<'_, Message> {

--- a/apps/cosmic/src/tray.rs
+++ b/apps/cosmic/src/tray.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+
+//! The tray icon.
+//!
+//! COSMIC has no tray of its own: the panel's status area is a
+//! StatusNotifierItem host, so the icon is an SNI on the session bus and `ksni`
+//! is what speaks it. That also means the icon is not guaranteed to exist —
+//! [`start`] says so, and the shell reads that as "the close button still
+//! closes the app", because a window with nowhere to go and no way back would
+//! leave the user with a process they cannot reach.
+//!
+//! The tray runs on its own thread and can only hand work over, never do it:
+//! everything it is asked for ends up as a [`Command`] the shell acts on.
+
+use std::sync::{Mutex, OnceLock};
+
+use cosmic::iced::futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use cosmic::iced::futures::{Stream, StreamExt};
+use cosmic::iced::Subscription;
+use ksni::blocking::TrayMethods;
+use ksni::menu::StandardItem;
+use ksni::MenuItem;
+
+/// What the tray can ask the shell to do. Nothing here is done by the tray
+/// itself — a menu callback that blocks would freeze the menu.
+#[derive(Clone, Copy, Debug)]
+pub enum Command {
+    /// Put the window back, or focus the one that is already there.
+    Show,
+    Lock,
+    Quit,
+}
+
+/// The receiving half of the channel, parked in a static because a
+/// [`Subscription`] is built from a bare `fn` with nothing captured. There is
+/// one tray per process, so there is nothing here that wants to be per-app.
+static COMMANDS: OnceLock<Mutex<Option<UnboundedReceiver<Command>>>> = OnceLock::new();
+
+struct Tray {
+    /// Doubles as the icon name: the desktop entry and the hicolor icons are
+    /// installed under the same id.
+    app_id: &'static str,
+    title: &'static str,
+    commands: UnboundedSender<Command>,
+}
+
+impl Tray {
+    /// The shell outlives the tray, so a closed channel only ever means the app
+    /// is already on its way out and there is no one left to tell.
+    fn send(&self, command: Command) {
+        let _ = self.commands.unbounded_send(command);
+    }
+
+    fn item(&self, label: &str, command: Command) -> MenuItem<Self> {
+        StandardItem {
+            label: label.to_string(),
+            activate: Box::new(move |tray: &mut Self| tray.send(command)),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl ksni::Tray for Tray {
+    fn id(&self) -> String {
+        self.app_id.to_string()
+    }
+
+    fn title(&self) -> String {
+        self.title.to_string()
+    }
+
+    fn icon_name(&self) -> String {
+        self.app_id.to_string()
+    }
+
+    fn activate(&mut self, _x: i32, _y: i32) {
+        self.send(Command::Show);
+    }
+
+    fn menu(&self) -> Vec<MenuItem<Self>> {
+        vec![
+            self.item("Show", Command::Show),
+            MenuItem::Separator,
+            self.item("Lock", Command::Lock),
+            self.item("Quit", Command::Quit),
+        ]
+    }
+}
+
+/// Dropping the handle takes the icon down with it, so it is parked for the
+/// life of the process rather than handed back for a caller to keep alive.
+static HANDLE: OnceLock<ksni::blocking::Handle<Tray>> = OnceLock::new();
+
+/// Puts the icon up, and says whether it went. `false` when the desktop has
+/// nowhere to put it — no StatusNotifierWatcher on the bus, or one with no host
+/// behind it.
+pub fn start(app_id: &'static str, title: &'static str) -> bool {
+    let (sender, receiver) = mpsc::unbounded();
+
+    let Ok(handle) = Tray {
+        app_id,
+        title,
+        commands: sender,
+    }
+    .spawn()
+    .inspect_err(|err| eprintln!("no tray: {err}")) else {
+        return false;
+    };
+
+    // Both only fail if `start` ran twice, which would leave the second tray
+    // talking to a channel nobody reads.
+    COMMANDS.set(Mutex::new(Some(receiver))).is_ok() && HANDLE.set(handle).is_ok()
+}
+
+/// The commands the tray has raised. Empty, and cheap, when there is no tray.
+pub fn subscription() -> Subscription<Command> {
+    Subscription::run(commands)
+}
+
+fn commands() -> impl Stream<Item = Command> {
+    // Taken rather than borrowed: iced builds a recipe once and keeps it, so a
+    // second call would only ever be a restart with nothing left to replay.
+    let receiver = COMMANDS
+        .get()
+        .and_then(|slot| slot.lock().ok().and_then(|mut slot| slot.take()));
+    cosmic::iced::futures::stream::iter(receiver).flatten()
+}


### PR DESCRIPTION
COSMIC has no tray of its own; the panel's status area is a StatusNotifierItem host, so this puts an SNI on the session bus with `ksni`.

Wayland cannot unmap a window and map it back — winit says so outright — so hiding destroys the window and showing builds a new one. Nothing is lost: all the state, including the unlocked session, lives in `App` rather than in the window, and the process survives with none because libcosmic runs as an iced daemon.

If nothing on the bus will take the icon the close button is left alone: a window with nowhere to go and no way back would leave a process the user cannot reach.

Verified on a live COSMIC session over D-Bus: the item registers with the right id, icon and title; hiding leaves the process running with no window; showing brings it back with its decorations; Quit from the menu exits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)