### PR TITLE
feat(cosmic): read the shared i18n catalogue

### DIFF
--- a/apps/cosmic/README.md
+++ b/apps/cosmic/README.md
@@ -39,6 +39,20 @@ shell acts on. Two rules keep this from eroding:
 - no `Option` for something that always exists once the app is running, which is
   why `Session` is not optional and a missing database is a separate shell state.
 
+## The catalogue
+
+The strings come from `i18n/` at the repo root, which
+the desktop app loads into `vue-i18n` and this one reads through
+`zann_ui_core::i18n` — one catalogue rather than two that drift. `screens/*.rs`
+ask for them by the dotted keys the JSON nests, so a string added for one client
+is one the other can already ask for by the same name, and the nav categories
+finally use their `schemas/ui_categories.json` label keys as the catalogue keys
+they always were. Unset means whatever `LC_ALL`/`LC_MESSAGES`/`LANG` asks for.
+
+Nothing checks those keys at compile time, so `every_key_the_app_asks_for_is_in_the_catalogue`
+does it instead: it reads the sources, picks out anything key-shaped, and fails
+on one the catalogue has never heard of.
+
 ## The three columns
 
 The open vault is the same shape as the Tauri app: nav categories, the item

--- a/apps/cosmic/src/i18n.rs
+++ b/apps/cosmic/src/i18n.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+
+//! The app's copy of the shared catalogue.
+//!
+//! The strings live in `i18n/` at the repo root and reach here through
+//! `zann-ui-core`, which is also where the desktop app gets them — so a string
+//! added for one client is a string the other can ask for by the same name.
+//!
+//! The catalogue is process-wide rather than threaded through every `view`.
+//! That is what `i18n-embed` does for the COSMIC apps, and for the same reason:
+//! a `view` that has to be handed a catalogue to name a button ends up carrying
+//! one through every widget that has nothing else to do with language.
+
+use std::sync::{OnceLock, RwLock};
+
+use zann_ui_core::i18n::Catalogue;
+
+fn catalogue() -> &'static RwLock<Catalogue> {
+    static CATALOGUE: OnceLock<RwLock<Catalogue>> = OnceLock::new();
+    CATALOGUE.get_or_init(|| RwLock::new(Catalogue::from_env()))
+}
+
+/// Switches language for everything drawn from here on. `None` means whatever
+/// the environment asks for, which is what an unset preference means.
+pub fn set_language(language: Option<&str>) {
+    let next = match language {
+        Some(tag) => Catalogue::new(tag),
+        None => Catalogue::from_env(),
+    };
+    if let Ok(mut current) = catalogue().write() {
+        *current = next;
+    }
+}
+
+/// The language actually in use, which is not always the one asked for — a tag
+/// with no catalogue behind it reads as English.
+pub fn language() -> String {
+    catalogue()
+        .read()
+        .map(|catalogue| catalogue.language().to_string())
+        .unwrap_or_else(|_| "en".to_string())
+}
+
+/// The string for a dotted key.
+///
+/// Returns an owned `String` because the catalogue sits behind a lock and the
+/// language can change under it. That is one small allocation per string per
+/// frame, against widgets that mostly want an owned string anyway.
+pub fn t(key: &str) -> String {
+    catalogue().read().map_or_else(
+        |_| key.to_string(),
+        |catalogue| catalogue.get(key).to_string(),
+    )
+}
+
+/// Whether the catalogue carries a key at all, in any language. For callers
+/// whose keys come from the data rather than from the source, like a field name.
+pub fn has(key: &str) -> bool {
+    catalogue().read().is_ok_and(|catalogue| catalogue.has(key))
+}
+
+/// The string for a key with its `{name}` placeholders filled in — the same
+/// spelling `vue-i18n` uses on the other side, so one catalogue entry serves
+/// both clients.
+///
+/// A placeholder with no argument is left as it is written: showing `{count}`
+/// says which one was forgotten, where dropping it would only look wrong.
+pub fn t_args(key: &str, args: &[(&str, &str)]) -> String {
+    let mut text = t(key);
+    for (name, value) in args {
+        text = text.replace(&format!("{{{name}}}"), value);
+    }
+    text
+}

--- a/apps/cosmic/src/lib.rs
+++ b/apps/cosmic/src/lib.rs
@@ -8,6 +8,7 @@
 //! `update(message) -> Outcome`.
 
 pub mod backend;
+pub mod i18n;
 pub mod screens;
 pub mod session;
 pub mod tray;

--- a/apps/cosmic/src/screens/connect.rs
+++ b/apps/cosmic/src/screens/connect.rs
@@ -11,6 +11,7 @@ use zann_ui_core::normalize_server_url;
 use super::centered;
 use crate::backend::off_thread;
 use crate::backend::remote::{LoginOutcome, Method, OidcStatus, Remote, ServerProbe};
+use crate::i18n::t;
 
 /// Which step of the flow the user is on.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -349,10 +350,10 @@ impl State {
         };
 
         let mut column = widget::column::with_capacity(5)
-            .push(widget::text::title3(match &self.stage {
-                Stage::Fingerprint { .. } => "Server key changed",
-                _ => "Connect to a server",
-            }))
+            .push(widget::text::title3(t(match &self.stage {
+                Stage::Fingerprint { .. } => "wizard.fingerprintChanged",
+                _ => "wizard.connectTitle",
+            })))
             .spacing(spacing.space_s)
             .width(Length::Fixed(420.0));
 
@@ -366,14 +367,17 @@ impl State {
             column = column.push(widget::text::caption(error.clone()));
         }
 
-        centered(column.push(widget::button::text("Back").on_press(Message::Cancel)))
+        centered(column.push(widget::button::text(t("wizard.back")).on_press(Message::Cancel)))
     }
 
     fn server_form(&self) -> Element<'_, Message> {
         let spacing = theme::spacing();
-        let mut submit =
-            widget::button::suggested(if self.busy { "Checking…" } else { "Continue" })
-                .width(Length::Fill);
+        let mut submit = widget::button::suggested(t(if self.busy {
+            "wizard.checking"
+        } else {
+            "common.continue"
+        }))
+        .width(Length::Fill);
         if !self.busy && !self.url.trim().is_empty() {
             submit = submit.on_press(Message::Probe);
         }
@@ -381,7 +385,7 @@ impl State {
         widget::column::with_capacity(2)
             .push(
                 widget::text_input::text_input("https://zann.example.com", &self.url)
-                    .label("Server URL")
+                    .label(t("auth.serverUrl"))
                     .on_input(Message::UrlInput)
                     .on_submit(|_| Message::Probe),
             )
@@ -393,15 +397,15 @@ impl State {
     fn method_picker(&self) -> Element<'_, Message> {
         let spacing = theme::spacing();
         let mut column = widget::column::with_capacity(self.methods.len() + 1)
-            .push(widget::text::body("Choose how to sign in."))
+            .push(widget::text::body(t("auth.selectMethod")))
             .spacing(spacing.space_s);
 
         for method in &self.methods {
             column = column.push(match method {
-                Method::Oidc => widget::button::standard("Single sign-on")
+                Method::Oidc => widget::button::standard(t("auth.oidc"))
                     .width(Length::Fill)
                     .on_press(Message::StartOidc),
-                Method::Password => widget::button::standard("Email and password")
+                Method::Password => widget::button::standard(t("auth.emailPassword"))
                     .width(Length::Fill)
                     .on_press(Message::ChoosePassword),
             });
@@ -414,12 +418,13 @@ impl State {
         let spacing = theme::spacing();
         let ready = !self.busy && !self.email.trim().is_empty() && !self.password.is_empty();
         let label = if self.register {
-            "Create the first account"
+            "auth.signUp"
         } else {
-            "Sign in"
+            "auth.signIn"
         };
-        let mut submit = widget::button::suggested(if self.busy { "Working…" } else { label })
-            .width(Length::Fill);
+        let mut submit =
+            widget::button::suggested(t(if self.busy { "auth.signingIn" } else { label }))
+                .width(Length::Fill);
         if ready {
             submit = submit.on_press(Message::SubmitPassword);
         }
@@ -427,15 +432,15 @@ impl State {
         let mut column = widget::column::with_capacity(4)
             .push(
                 widget::text_input::text_input("you@example.com", &self.email)
-                    .label("Email")
+                    .label(t("auth.email"))
                     .on_input(Message::EmailInput),
             )
             .spacing(spacing.space_s);
 
         if self.register {
             column = column.push(
-                widget::text_input::text_input("Full name", &self.full_name)
-                    .label("Full name")
+                widget::text_input::text_input(t("auth.fullName"), &self.full_name)
+                    .label(t("auth.fullName"))
                     .on_input(Message::FullNameInput),
             );
         }
@@ -443,12 +448,12 @@ impl State {
         column
             .push(
                 widget::text_input::secure_input(
-                    "Password",
+                    t("auth.password"),
                     &self.password,
                     Some(Message::TogglePassword),
                     self.password_hidden,
                 )
-                .label("Password")
+                .label(t("auth.password"))
                 .on_input(Message::PasswordInput)
                 .on_submit(|_| Message::SubmitPassword),
             )
@@ -463,21 +468,18 @@ impl State {
         match self.authorization_url.as_ref() {
             Some(_) => {
                 column = column
-                    .push(widget::text::body(
-                        "Finish signing in in your browser, then come back here.",
-                    ))
+                    .push(widget::text::body(t("wizard.oidcHint")))
                     .push(
-                        widget::button::link("Open the sign-in page again")
-                            .on_press(Message::OpenAuthUrl),
+                        widget::button::link(t("wizard.oidcReopen")).on_press(Message::OpenAuthUrl),
                     )
-                    .push(widget::button::text("Copy the link").on_press(Message::CopyAuthUrl));
+                    .push(widget::button::text(t("auth.copyLink")).on_press(Message::CopyAuthUrl));
             }
             None => {
-                let mut start = widget::button::suggested(if self.busy {
-                    "Starting…"
+                let mut start = widget::button::suggested(t(if self.busy {
+                    "wizard.starting"
                 } else {
-                    "Sign in with SSO"
-                })
+                    "wizard.signInSso"
+                }))
                 .width(Length::Fill);
                 if !self.busy {
                     start = start.on_press(Message::StartOidc);
@@ -491,19 +493,17 @@ impl State {
 
     fn fingerprint_prompt<'a>(&'a self, old: &'a str, new: &'a str) -> Element<'a, Message> {
         let spacing = theme::spacing();
-        let mut trust = widget::button::destructive("Trust the new key").width(Length::Fill);
+        let mut trust =
+            widget::button::destructive(t("wizard.trustFingerprint")).width(Length::Fill);
         if !self.busy {
             trust = trust.on_press(Message::TrustFingerprint);
         }
 
         widget::column::with_capacity(6)
-            .push(widget::text::body(
-                "This server presents a different key than the one you trusted. \
-                 Only continue if you know why it changed.",
-            ))
-            .push(widget::text::caption("Previously trusted"))
+            .push(widget::text::body(t("wizard.fingerprintWarning")))
+            .push(widget::text::caption(t("wizard.oldFingerprint")))
             .push(widget::text::monotext(old.to_string()))
-            .push(widget::text::caption("Now offered"))
+            .push(widget::text::caption(t("wizard.newFingerprint")))
             .push(widget::text::monotext(new.to_string()))
             .push(trust)
             .spacing(spacing.space_xxs)

--- a/apps/cosmic/src/screens/detail.rs
+++ b/apps/cosmic/src/screens/detail.rs
@@ -8,6 +8,8 @@ use zann_crypto::secrets::{EncryptedPayload, FieldKind};
 use zann_ffi::ItemDetail;
 use zann_ui_core::{generate_totp, TotpParams};
 
+use crate::i18n::{has, t};
+
 /// Fields the schemas put first, in the order a reader expects them.
 const FIELD_ORDER: &[&str] = &[
     "username", "email", "password", "otp", "totp", "url", "key", "value", "notes",
@@ -111,7 +113,7 @@ impl Detail {
             .spacing(spacing.space_s);
 
         if self.fields.is_empty() {
-            column = column.push(widget::text::body("This item has no fields."));
+            column = column.push(widget::text::body(t("items.noFields")));
         }
 
         for (index, field) in self.fields.iter().enumerate() {
@@ -161,16 +163,13 @@ fn totp_params(value: &str, payload: &EncryptedPayload) -> TotpParams {
     params
 }
 
+/// Field names are catalogue keys under `fields.`, which is where the desktop
+/// app looks them up too. A name the catalogue has never heard of is spelled out
+/// from the key rather than shown as one.
 fn label_for(key: &str) -> String {
     match key {
-        "username" => "Username".to_string(),
-        "password" => "Password".to_string(),
-        "url" => "URL".to_string(),
-        "notes" => "Notes".to_string(),
-        "email" => "Email".to_string(),
-        "card_number" => "Card number".to_string(),
-        "cvv" => "CVV".to_string(),
-        "otp" | "totp" => "One-time code".to_string(),
+        "otp" | "totp" => t("fields.otp"),
+        named if has(&format!("fields.{named}")) => t(&format!("fields.{named}")),
         other => {
             let spaced = other.replace('_', " ");
             let mut chars = spaced.chars();

--- a/apps/cosmic/src/screens/master.rs
+++ b/apps/cosmic/src/screens/master.rs
@@ -6,6 +6,7 @@ use cosmic::{theme, widget, Element};
 use super::centered;
 use crate::backend::local::{self, ItemsPage};
 use crate::backend::off_thread;
+use crate::i18n::t;
 use crate::session::Session;
 
 /// Whether the screen creates a vault or opens one that already exists.
@@ -109,21 +110,25 @@ impl State {
     pub fn view(&self) -> Element<'_, Message> {
         let spacing = theme::spacing();
         let (title, action) = match self.mode {
-            Mode::Create => ("Choose a master password", "Create the vault"),
-            Mode::Unlock => ("Unlock your vault", "Unlock"),
+            Mode::Create => ("wizard.passwordTitle", "wizard.create"),
+            Mode::Unlock => ("unlock.title", "common.unlock"),
         };
 
-        let mut submit = widget::button::suggested(if self.busy { "Working…" } else { action })
-            .width(Length::Fill);
+        let mut submit = widget::button::suggested(t(if self.busy {
+            "wizard.processing"
+        } else {
+            action
+        }))
+        .width(Length::Fill);
         if !self.busy && !self.password.is_empty() {
             submit = submit.on_press(Message::Submit);
         }
 
         let mut form = widget::column::with_capacity(5)
-            .push(widget::text::title3(title))
+            .push(widget::text::title3(t(title)))
             .push(
                 widget::text_input::secure_input(
-                    "Master password",
+                    t("wizard.passwordPlaceholder"),
                     &self.password,
                     Some(Message::ToggleVisibility),
                     self.hidden,
@@ -135,15 +140,11 @@ impl State {
             .width(Length::Fixed(360.0));
 
         if self.mode == Mode::Create {
-            form = form.push(widget::text::caption(
-                "At least 8 characters. It is never sent to the server.",
-            ));
+            form = form.push(widget::text::caption(t("wizard.passwordSubtitle")));
         }
 
         if self.sync_after.is_some() {
-            form = form.push(widget::text::caption(
-                "The vault will sync with the server right after this.",
-            ));
+            form = form.push(widget::text::caption(t("wizard.syncAfterUnlock")));
         }
 
         if let Some(error) = self.error.as_ref() {

--- a/apps/cosmic/src/screens/vault.rs
+++ b/apps/cosmic/src/screens/vault.rs
@@ -19,25 +19,8 @@ use zann_ui_core::{
 use super::detail::{self, Detail};
 use crate::backend::local::{self, ItemsPage};
 use crate::backend::off_thread;
+use crate::i18n::{t, t_args};
 use crate::session::Session;
-
-/// Label keys come from `schemas/ui_categories.json`; until the clients share
-/// an i18n catalogue every frontend maps them itself.
-fn translate_label_key(key: &str) -> &'static str {
-    match key {
-        "nav.allItems" => "All items",
-        "nav.logins" => "Logins",
-        "nav.notes" => "Notes",
-        "nav.cards" => "Cards",
-        "nav.identity" => "Identity",
-        "nav.api" => "API keys",
-        "nav.kv" => "Key/Value",
-        "nav.infrastructure" => "Infrastructure",
-        "nav.trash" => "Trash",
-        "items.trashShared" => "Shared trash",
-        _ => "Unknown",
-    }
-}
 
 /// Schema icon names mapped onto the freedesktop names COSMIC ships.
 fn category_icon(schema_icon: &str) -> &'static str {
@@ -138,7 +121,7 @@ impl State {
             nav: nav_bar::Model::default(),
             detail: None,
             busy: false,
-            error: sync_error.map(|err| format!("sync failed: {err}")),
+            error: sync_error.map(|err| t_args("items.syncFailed", &[("error", &err)])),
             list_width: layout::LIST_DEFAULT,
             // Enough for the default split until the shell reports the window.
             content_width: layout::LIST_DEFAULT + layout::HANDLE + layout::DETAIL_MIN,
@@ -330,7 +313,7 @@ impl State {
         let spacing = theme::spacing();
 
         let Some(detail) = self.detail.as_ref() else {
-            return super::centered(widget::text::body("Select an item to read it."));
+            return super::centered(widget::text::body(t("items.detailsHint")));
         };
 
         let header = widget::row::with_capacity(2)
@@ -356,17 +339,17 @@ impl State {
 
         let toolbar = widget::row::with_capacity(2)
             .push(
-                widget::text_input::search_input("Search items", &self.query)
+                widget::text_input::search_input(t("items.searchPlaceholder"), &self.query)
                     .on_input(Message::QueryInput)
                     .on_clear(Message::ClearQuery)
                     .width(Length::Fill),
             )
-            .push(widget::button::standard("Lock").on_press(Message::Lock))
+            .push(widget::button::standard(t("common.lock")).on_press(Message::Lock))
             .spacing(spacing.space_xs)
             .align_y(Alignment::Center);
 
         let list: Element<'_, Message> = if visible.is_empty() {
-            widget::text::body("Nothing here.")
+            widget::text::body(t("items.noItems"))
                 .apply(widget::container)
                 .width(Length::Fill)
                 .padding(spacing.space_m)
@@ -385,17 +368,19 @@ impl State {
         };
 
         let mut footer = widget::row::with_capacity(2)
-            .push(widget::text::caption(format!(
-                "{} of {} items loaded, {} shown",
-                self.items.len(),
-                self.total,
-                visible.len()
+            .push(widget::text::caption(t_args(
+                "items.loadedCount",
+                &[
+                    ("loaded", &self.items.len().to_string()),
+                    ("total", &self.total.to_string()),
+                    ("shown", &visible.len().to_string()),
+                ],
             )))
             .spacing(spacing.space_xs)
             .align_y(Alignment::Center);
 
         if self.next_cursor.is_some() {
-            let mut more = widget::button::text("Load more");
+            let mut more = widget::button::text(t("items.loadMore"));
             if !self.busy {
                 more = more.on_press(Message::LoadMore);
             }
@@ -433,7 +418,9 @@ impl State {
         let selected = self.selected_category();
         self.nav.clear();
         for view in category_views(&self.counts, VaultScope::Personal) {
-            let label = format!("{} ({})", translate_label_key(&view.label_key), view.count);
+            // The label key is a catalogue key: `schemas/ui_categories.json` names
+            // the same strings the clients translate.
+            let label = format!("{} ({})", t(&view.label_key), view.count);
             let entity = self
                 .nav
                 .insert()

--- a/apps/cosmic/src/screens/welcome.rs
+++ b/apps/cosmic/src/screens/welcome.rs
@@ -7,6 +7,7 @@ use cosmic::iced::Length;
 use cosmic::{theme, widget, Element};
 
 use super::centered;
+use crate::i18n::t;
 
 #[derive(Clone, Debug)]
 pub enum Message {
@@ -18,17 +19,15 @@ pub fn view<'a>() -> Element<'a, Message> {
     let spacing = theme::spacing();
     centered(
         widget::column::with_capacity(4)
-            .push(widget::text::title3("Welcome to zann"))
-            .push(widget::text::body(
-                "Keep the vault on this machine, or connect it to a server.",
-            ))
+            .push(widget::text::title3(t("wizard.title")))
+            .push(widget::text::body(t("wizard.subtitle")))
             .push(
-                widget::button::suggested("Connect to a server")
+                widget::button::suggested(t("wizard.connect"))
                     .width(Length::Fill)
                     .on_press(Message::ConnectToServer),
             )
             .push(
-                widget::button::standard("Use a local vault")
+                widget::button::standard(t("wizard.startLocal"))
                     .width(Length::Fill)
                     .on_press(Message::UseLocalVault),
             )

--- a/apps/cosmic/src/tray.rs
+++ b/apps/cosmic/src/tray.rs
@@ -21,6 +21,8 @@ use ksni::blocking::TrayMethods;
 use ksni::menu::StandardItem;
 use ksni::MenuItem;
 
+use crate::i18n::t;
+
 /// What the tray can ask the shell to do. Nothing here is done by the tray
 /// itself — a menu callback that blocks would freeze the menu.
 #[derive(Clone, Copy, Debug)]
@@ -51,9 +53,9 @@ impl Tray {
         let _ = self.commands.unbounded_send(command);
     }
 
-    fn item(&self, label: &str, command: Command) -> MenuItem<Self> {
+    fn item(&self, key: &str, command: Command) -> MenuItem<Self> {
         StandardItem {
-            label: label.to_string(),
+            label: t(key),
             activate: Box::new(move |tray: &mut Self| tray.send(command)),
             ..Default::default()
         }
@@ -80,10 +82,10 @@ impl ksni::Tray for Tray {
 
     fn menu(&self) -> Vec<MenuItem<Self>> {
         vec![
-            self.item("Show", Command::Show),
+            self.item("common.show", Command::Show),
             MenuItem::Separator,
-            self.item("Lock", Command::Lock),
-            self.item("Quit", Command::Quit),
+            self.item("common.lock", Command::Lock),
+            self.item("common.quit", Command::Quit),
         ]
     }
 }

--- a/apps/cosmic/tests/flows.rs
+++ b/apps/cosmic/tests/flows.rs
@@ -208,6 +208,76 @@ fn the_splitter_stays_between_the_two_minimums() {
     assert_eq!(state.list_width(), 460.0);
 }
 
+/// The catalogue is looked up by string, so nothing stops a typo reaching the
+/// screen as its own key. This is the check the compiler cannot do: every key
+/// the sources ask for has to exist.
+#[test]
+fn every_key_the_app_asks_for_is_in_the_catalogue() {
+    let catalogue = zann_ui_core::i18n::Catalogue::new("en");
+    let mut missing = Vec::new();
+
+    for entry in walk_sources("src") {
+        let source = std::fs::read_to_string(&entry).expect("read a source file");
+        for key in literal_keys(&source) {
+            // `fields.<name>` is built from the item's own field names, which
+            // are data and are meant to fall through to a spelled-out label.
+            if !key.starts_with("fields.") && !catalogue.has(&key) {
+                missing.push(format!("{}: {key}", entry.display()));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "keys with no catalogue entry: {missing:#?}"
+    );
+}
+
+/// Every `"a.b"`-shaped string literal in a source file. Dotted lowercase with
+/// no spaces is what a catalogue key looks like — and, as it turns out, what a
+/// filename looks like too, so those are named and skipped.
+fn literal_keys(source: &str) -> Vec<String> {
+    const FILE_SUFFIXES: &[&str] = &[".json", ".sqlite", ".rs", ".toml", ".png", ".desktop"];
+
+    let mut keys = Vec::new();
+    for piece in source.split('"').skip(1).step_by(2) {
+        if FILE_SUFFIXES.iter().any(|suffix| piece.ends_with(suffix)) {
+            continue;
+        }
+        let looks_like_a_key = piece.contains('.')
+            && !piece.contains(' ')
+            && !piece.contains('/')
+            && !piece.contains('{')
+            && piece
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_')
+            && piece.split('.').all(|part| {
+                part.chars().next().is_some_and(char::is_lowercase) && !part.is_empty()
+            })
+            && piece.split('.').count() >= 2;
+        if looks_like_a_key {
+            keys.push(piece.to_string());
+        }
+    }
+    keys
+}
+
+fn walk_sources(root: &str) -> Vec<std::path::PathBuf> {
+    let mut found = Vec::new();
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return found;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            found.extend(walk_sources(&path.to_string_lossy()));
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            found.push(path);
+        }
+    }
+    found
+}
+
 #[test]
 fn connect_walks_the_stages_a_server_dictates() {
     let mut state = connect::State::default();

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,7 +25,11 @@
     "continue": "Continue",
     "undo": "Undo",
     "save": "Save",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "lock": "Lock",
+    "open": "Open",
+    "show": "Show",
+    "quit": "Quit"
   },
   "sidebar": {
     "collapse": "Collapse sidebar",
@@ -79,7 +83,8 @@
     "mime": "MIME Type",
     "size": "Size",
     "checksum": "Checksum",
-    "protocol": "Protocol"
+    "protocol": "Protocol",
+    "otp": "One-time code"
   },
   "nav": {
     "vaults": "Vaults",
@@ -219,7 +224,11 @@
     "historyAfter": "After",
     "historyDraftNotice": "Draft changes staged. Use Edit to save.",
     "resolveConflict": "Resolve conflict",
-    "resolveConflictDone": "Conflict marked for sync"
+    "resolveConflictDone": "Conflict marked for sync",
+    "loadMore": "Load more",
+    "noFields": "This item has no fields.",
+    "loadedCount": "{loaded} of {total} loaded, {shown} shown",
+    "syncFailed": "Sync failed: {error}"
   },
   "totp": {
     "refreshEvery": "refresh every {seconds}s",
@@ -271,7 +280,9 @@
     "passwordMismatch": "Passwords do not match.",
     "currentAccount": "current account",
     "registerWillSignOutTitle": "Sign out of current session?",
-    "registerWillSignOutDesc": "You are signed in as {email}. Creating a new account will sign you out. Continue?"
+    "registerWillSignOutDesc": "You are signed in as {email}. Creating a new account will sign you out. Continue?",
+    "copyLink": "Copy the link",
+    "serverUrl": "Server URL"
   },
   "wizard": {
     "loading": "Loading...",
@@ -315,7 +326,14 @@
     "oldFingerprint": "Old fingerprint",
     "newFingerprint": "New fingerprint",
     "trustFingerprint": "Trust new fingerprint",
-    "unknown": "Unknown"
+    "unknown": "Unknown",
+    "syncAfterUnlock": "The vault will sync with the server right after this.",
+    "fingerprintWarning": "This server presents a different key than the one you trusted. Only continue if you know why it changed.",
+    "oidcHint": "Finish signing in in your browser, then come back here.",
+    "oidcReopen": "Open the sign-in page again",
+    "signInSso": "Sign in with SSO",
+    "starting": "Starting…",
+    "checking": "Checking…"
   },
   "settings": {
     "title": "Settings",
@@ -337,7 +355,8 @@
       "trashRetentionHelp": "Only deletes items that are already synced.",
       "trashRetentionNever": "Never",
       "trashRetention30": "After 30 days",
-      "trashRetention90": "After 90 days"
+      "trashRetention90": "After 90 days",
+      "languageSystem": "System"
     },
     "security": "Security",
     "autolock": "Auto-lock",
@@ -496,7 +515,6 @@
     "rowView": "Row view",
     "jsonView": "JSON view",
     "keyLabel": "Key",
-    "valueLabel": "Value",
     "actionsLabel": "Actions",
     "advanced": "Advanced",
     "customFields": "Custom fields",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -25,7 +25,11 @@
     "continue": "Продолжить",
     "undo": "Отменить",
     "save": "Сохранить",
-    "loading": "Загрузка..."
+    "loading": "Загрузка...",
+    "lock": "Заблокировать",
+    "open": "Открыть",
+    "show": "Показать",
+    "quit": "Выйти"
   },
   "sidebar": {
     "collapse": "Свернуть панель",
@@ -79,7 +83,8 @@
     "mime": "MIME тип",
     "size": "Размер",
     "checksum": "Контрольная сумма",
-    "protocol": "Протокол"
+    "protocol": "Протокол",
+    "otp": "Одноразовый код"
   },
   "nav": {
     "vaults": "Хранилища",
@@ -219,7 +224,11 @@
     "historyAfter": "После",
     "historyDraftNotice": "Изменения подготовлены. Нажмите «Редактировать», чтобы сохранить.",
     "resolveConflict": "Разрешить конфликт",
-    "resolveConflictDone": "Конфликт отправлен на синхронизацию"
+    "resolveConflictDone": "Конфликт отправлен на синхронизацию",
+    "loadMore": "Загрузить ещё",
+    "noFields": "У этой записи нет полей.",
+    "loadedCount": "загружено {loaded} из {total}, показано {shown}",
+    "syncFailed": "Синхронизация не удалась: {error}"
   },
   "totp": {
     "refreshEvery": "обновляется каждые {seconds}с",
@@ -271,7 +280,9 @@
     "passwordMismatch": "Пароли не совпадают.",
     "currentAccount": "текущая учетная запись",
     "registerWillSignOutTitle": "Выйти из текущей сессии?",
-    "registerWillSignOutDesc": "Вы вошли как {email}. Создание нового аккаунта завершит текущую сессию. Продолжить?"
+    "registerWillSignOutDesc": "Вы вошли как {email}. Создание нового аккаунта завершит текущую сессию. Продолжить?",
+    "copyLink": "Скопировать ссылку",
+    "serverUrl": "Адрес сервера"
   },
   "wizard": {
     "loading": "Загрузка...",
@@ -315,7 +326,14 @@
     "oldFingerprint": "Старый отпечаток",
     "newFingerprint": "Новый отпечаток",
     "trustFingerprint": "Доверять новому отпечатку",
-    "unknown": "Неизвестно"
+    "unknown": "Неизвестно",
+    "syncAfterUnlock": "Сразу после этого хранилище синхронизируется с сервером.",
+    "fingerprintWarning": "Сервер предъявляет ключ, отличный от того, которому вы доверились. Продолжайте, только если знаете, почему он сменился.",
+    "oidcHint": "Завершите вход в браузере и вернитесь сюда.",
+    "oidcReopen": "Открыть страницу входа заново",
+    "signInSso": "Войти через SSO",
+    "starting": "Запуск…",
+    "checking": "Проверяем…"
   },
   "settings": {
     "title": "Настройки",
@@ -337,7 +355,8 @@
       "trashRetentionHelp": "Удаляются только записи, которые уже синхронизированы.",
       "trashRetentionNever": "Никогда",
       "trashRetention30": "Через 30 дней",
-      "trashRetention90": "Через 90 дней"
+      "trashRetention90": "Через 90 дней",
+      "languageSystem": "Системный"
     },
     "security": "Безопасность",
     "autolock": "Автоблокировка",
@@ -496,7 +515,6 @@
     "rowView": "Таблица",
     "jsonView": "JSON",
     "keyLabel": "Ключ",
-    "valueLabel": "Значение",
     "actionsLabel": "Действия",
     "advanced": "Дополнительно",
     "customFields": "Свои поля",


### PR DESCRIPTION
Replaces the hardcoded English with the catalogue from `i18n/`. `translate_label_key` goes away entirely — the nav categories' label keys from `schemas/ui_categories.json` were catalogue keys all along, which is what the comment above it had been promising.

Around 40 strings mapped onto keys the desktop already had; 19 new ones added to both languages. Language follows the environment.

Nothing checks the keys at compile time, so a test does it instead: it reads the sources, picks out anything key-shaped, and fails on one the catalogue has never heard of.

Verified: `cargo fmt`, `clippy`, `cargo test` (8). Run with `LANG=ru_RU.UTF-8` the window and the tray menu come up in Russian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)