### PR TITLE
feat(cosmic): carry over the desktop settings

### DIFF
--- a/apps/cosmic/Cargo.lock
+++ b/apps/cosmic/Cargo.lock
@@ -7948,6 +7948,7 @@ dependencies = [
  "libcosmic",
  "open",
  "reqwest",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",

--- a/apps/cosmic/Cargo.toml
+++ b/apps/cosmic/Cargo.toml
@@ -30,6 +30,7 @@ libcosmic = { git = "https://github.com/pop-os/libcosmic", rev = "dc1cf9f00cbe29
 ] }
 open = "5"
 reqwest = { version = "0.12", features = ["rustls-tls"] }
+serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 zann-client = { path = "../../crates/zann-client" }

--- a/apps/cosmic/README.md
+++ b/apps/cosmic/README.md
@@ -101,7 +101,60 @@ If nothing on the bus will take the icon, `tray::start` says so and the close
 button is left alone — a window with nowhere to go and no way back would leave
 a process the user cannot reach.
 
-The vault stays unlocked in the tray, the way the desktop app leaves it.
+Whether it hides or quits is a setting, so neither the header button nor the
+compositor decides it — both come back as one message and the shell reads the
+preference then. The vault stays unlocked in the tray, the way the desktop app
+leaves it.
+
+## Settings
+
+`src/settings.rs` carries the desktop app's `DesktopSettings` names and its
+defaults, so "auto-lock after 10 minutes" means the same thing in both clients.
+The file is not shared: `desktop.json` holds a wrapped master key and a biometry
+backup this app cannot produce, and a round trip through a struct without those
+fields would drop them, so this one writes `cosmic.json` beside it.
+
+The screen is `screens/settings.rs`, reached from the gear in the header bar and
+from the tray. It is drawn with `widget::settings::section`, the same rows
+cosmic-settings uses, and it lays over whatever is underneath instead of
+replacing it — opening it must not throw away the vault's list and its scroll.
+
+Three of the desktop's five tabs are here, and the two that are missing are
+missing for a reason rather than for now:
+
+- **Backups** sits on `backup_export_file` / `backup_import_file`, which
+  `zann-ffi` answers with `Unimplemented`. The desktop does that work on its own
+  side, so there is nothing for this client to call.
+- **The keystore block** under Security — remember, auto-unlock, Touch ID — is
+  inert on Linux for *both* clients: `zann-keystore` implements macOS and
+  answers `supported: false` everywhere else, which is what greys the whole
+  block out in the desktop app too.
+
+Accounts is here but thinner than the desktop's: listing storages and syncing
+one go through the facade, while sign-out, clear-data and factory-reset are
+Tauri-side commands with no `zann-ffi` behind them.
+
+Language is one of them. The strings come from `i18n/` at the repo root, which
+the desktop app loads into `vue-i18n` and this one reads through
+`zann_ui_core::i18n` — one catalogue rather than two that drift. `screens/*.rs`
+ask for them by the dotted keys the JSON nests, so a string added for one client
+is one the other can already ask for by the same name, and the nav categories
+finally use their `schemas/ui_categories.json` label keys as the catalogue keys
+they always were. Unset means whatever `LC_ALL`/`LC_MESSAGES`/`LANG` asks for.
+
+Nothing checks those keys at compile time, so `every_key_the_app_asks_for_is_in_the_catalogue`
+does it instead: it reads the sources, picks out anything key-shaped, and fails
+on one the catalogue has never heard of.
+
+Everything that is here is wired, not just drawn. Idle is measured from discrete
+input — keys, clicks, the wheel — rather than from the pointer crossing the
+window, because a mouse nudged by a cat is not someone reading their vault and
+believing otherwise would cost a redraw per motion event.
+
+The clipboard and the reveal both hand a timer to the runtime, and a task once
+handed over cannot be called back. Both therefore carry a count: a timer that
+fires for a copy or a reveal that has since been replaced recognises itself and
+does nothing.
 
 ## Prereqs
 

--- a/apps/cosmic/src/backend/local.rs
+++ b/apps/cosmic/src/backend/local.rs
@@ -2,7 +2,10 @@
 
 use std::sync::Arc;
 
-use zann_ffi::{create_core, AppStatusFfi, CoreFacade, ItemDetail, ItemSummary, ItemsFilter, Page};
+use zann_ffi::{
+    create_core, AppStatusFfi, CoreFacade, ItemDetail, ItemSummary, ItemsFilter, Page,
+    StorageSummaryFfi,
+};
 use zann_ui_core::ItemCounts;
 
 use super::{default_db_url, local_root};
@@ -86,4 +89,11 @@ pub fn items(facade: &CoreFacade, cursor: Option<String>) -> Result<ItemsPage, S
 
 pub fn item_get(facade: &CoreFacade, id: String) -> Result<ItemDetail, String> {
     facade.item_get(id).map_err(|err| err.to_string())
+}
+
+/// The servers and local vaults this machine knows about. One small read with
+/// no key derivation behind it, so unlike the rest of this module it is cheap
+/// enough to call straight from an update.
+pub fn storages(facade: &CoreFacade) -> Result<Vec<StorageSummaryFfi>, String> {
+    facade.list_storages().map_err(|err| err.to_string())
 }

--- a/apps/cosmic/src/backend/mod.rs
+++ b/apps/cosmic/src/backend/mod.rs
@@ -37,7 +37,7 @@ fn local_root() -> PathBuf {
 }
 
 /// The client state and identity config live next to the database file.
-fn client_root(db_url: &str) -> PathBuf {
+pub(crate) fn client_root(db_url: &str) -> PathBuf {
     db_url
         .strip_prefix("sqlite://")
         .and_then(|path| Path::new(path).parent().map(Path::to_path_buf))

--- a/apps/cosmic/src/lib.rs
+++ b/apps/cosmic/src/lib.rs
@@ -11,4 +11,5 @@ pub mod backend;
 pub mod i18n;
 pub mod screens;
 pub mod session;
+pub mod settings;
 pub mod tray;

--- a/apps/cosmic/src/main.rs
+++ b/apps/cosmic/src/main.rs
@@ -12,18 +12,26 @@
 //! [`Session`], and the routing between screens. Each screen in [`screens`]
 //! owns its own state and messages and reports back through its `Outcome`.
 
+use std::time::{Duration, Instant};
+
 use cosmic::app::{Core, Settings, Task};
 use cosmic::iced::core::layout::Limits;
-use cosmic::iced::{event, window, Event, Size, Subscription};
+use cosmic::iced::{event, keyboard, mouse, window, Event, Size, Subscription};
 use cosmic::prelude::*;
 use cosmic::widget::nav_bar;
-use cosmic::{executor, Application, Element};
-use zann_cosmic::screens::{self, connect, master, vault, welcome, Screen};
+use cosmic::{executor, widget, Application, Element};
+use zann_cosmic::backend::{self, local};
+use zann_cosmic::i18n;
+use zann_cosmic::screens::{self, connect, master, settings, vault, welcome, Screen};
 use zann_cosmic::session::Session;
+use zann_cosmic::settings::{Change, Settings as AppSettings};
 use zann_cosmic::tray;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Held for the whole run: dropping this takes the icon down with it.
+    // Ahead of the tray, whose menu labels come from the catalogue and would
+    // otherwise be built in whatever language the environment happens to ask
+    // for rather than the one that was chosen.
+    i18n::set_language(AppSettings::load().language.as_deref());
     let has_tray = tray::start(App::APP_ID, "zann");
 
     let settings = Settings::default()
@@ -33,9 +41,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .min_width(WINDOW_MIN.width)
                 .min_height(WINDOW_MIN.height),
         )
-        // Without a tray the window has nowhere to go and no way back, so the
-        // close button has to keep meaning what it says.
-        .exit_on_close(!has_tray);
+        // Never libcosmic's call. Closing is a preference that can change while
+        // the app runs, so both the header button and the compositor come back
+        // as messages and the shell decides then — see `close_intent`.
+        .exit_on_close(false);
 
     cosmic::app::run::<App>(settings, has_tray)?;
     Ok(())
@@ -58,6 +67,10 @@ const NAV_WIDTH: f32 = 288.0;
 const WINDOW_SIZE: Size = Size::new(1200.0, 700.0);
 const WINDOW_MIN: Size = Size::new(1125.0, 650.0);
 
+/// How often the idle check runs. Coarse on purpose: the shortest auto-lock the
+/// settings offer is a minute, so a finer tick would only burn wakeups.
+const IDLE_TICK: Duration = Duration::from_secs(15);
+
 struct App {
     core: Core,
     shell: Shell,
@@ -68,6 +81,15 @@ struct App {
     /// Wayland cannot unmap a window and map it back, so hiding destroys it and
     /// showing builds a new one. This is what says which of the two it is.
     window_open: bool,
+    settings: AppSettings,
+    /// Shown over whatever is underneath rather than replacing it, so opening
+    /// the settings does not throw away the vault's list and its scroll.
+    settings_screen: Option<Box<settings::State>>,
+    last_activity: Instant,
+    /// What we last put on the clipboard, and how many times we have put
+    /// something there. A timer cannot be cancelled once handed to the runtime,
+    /// so the count is what lets a stale one recognise itself and do nothing.
+    clipboard: (String, u64),
 }
 
 #[derive(Clone, Debug)]
@@ -76,15 +98,27 @@ enum Message {
     Connect(connect::Message),
     Master(master::Message),
     Vault(vault::Message),
+    Settings(settings::Message),
     /// Effects the shell owns because they leave the app.
     Copy(String),
     OpenUrl(String),
     Tray(tray::Command),
+    OpenSettings,
     /// The user asked for the window to go away — from the header bar, or from
-    /// the compositor.
-    HideWindow,
+    /// the compositor. What that means is a setting.
+    CloseIntent,
     /// A window is gone, whoever closed it.
     WindowClosed,
+    Unfocused,
+    IdleTick,
+    /// Any input at all. Only for the idle clock, so it carries nothing.
+    Activity,
+    /// The clipboard's time is up, for the copy that was current when it
+    /// started. A newer copy makes this a no-op.
+    ClipboardExpired(u64),
+    /// What the clipboard holds now, so a copy that is no longer ours is left
+    /// alone.
+    ClipboardRead(Option<String>),
 }
 
 /// Lifts a screen's task into the shell's message type.
@@ -113,6 +147,8 @@ impl cosmic::Application for App {
     }
 
     fn init(core: Core, has_tray: Self::Flags) -> (Self, Task<Self::Message>) {
+        let settings = AppSettings::load();
+
         let shell = match Session::open() {
             Ok((session, status)) => {
                 let screen = if status.initialized {
@@ -135,6 +171,10 @@ impl cosmic::Application for App {
             window_width: WINDOW_SIZE.width,
             has_tray,
             window_open: true,
+            settings,
+            settings_screen: None,
+            last_activity: Instant::now(),
+            clipboard: (String::new(), 0),
         };
         app.set_header_title("zann".to_string());
         let task = match app.core.main_window_id() {
@@ -147,7 +187,7 @@ impl cosmic::Application for App {
     /// The header bar's close button. Returning a message is what stops
     /// libcosmic from closing the window itself, so the shell gets to decide.
     fn on_app_exit(&mut self) -> Option<Self::Message> {
-        self.has_tray.then_some(Message::HideWindow)
+        Some(Message::CloseIntent)
     }
 
     /// Called once a surface is gone. Popups close too, so only the one the
@@ -158,39 +198,29 @@ impl cosmic::Application for App {
             .then_some(Message::WindowClosed)
     }
 
-    /// The nav bar belongs to the vault screen.
+    /// The way into the settings, where the system apps keep theirs.
+    fn header_end(&self) -> Vec<Element<'_, Self::Message>> {
+        if matches!(self.shell, Shell::Blocked(_)) || self.settings_screen.is_some() {
+            return Vec::new();
+        }
+        vec![
+            widget::button::icon(widget::icon::from_name("preferences-system-symbolic"))
+                .on_press(Message::OpenSettings)
+                .into(),
+        ]
+    }
+
+    /// The nav bar belongs to the vault screen, and the settings cover it.
     fn nav_model(&self) -> Option<&nav_bar::Model> {
+        if self.settings_screen.is_some() {
+            return None;
+        }
         match &self.shell {
             Shell::Ready {
                 screen: Screen::Vault(vault),
                 ..
             } => Some(vault.nav_model()),
             _ => None,
-        }
-    }
-
-    fn on_nav_select(&mut self, id: nav_bar::Id) -> Task<Self::Message> {
-        if let Shell::Ready {
-            screen: Screen::Vault(vault),
-            ..
-        } = &mut self.shell
-        {
-            vault.activate_nav(id);
-        }
-        Task::none()
-    }
-
-    /// The vault lays its two columns out itself, so it has to be told how much
-    /// of the window the nav bar left it.
-    fn on_window_resize(&mut self, _id: cosmic::iced::window::Id, width: f32, _height: f32) {
-        self.window_width = width;
-        let content_width = self.content_width();
-        if let Shell::Ready {
-            screen: Screen::Vault(vault),
-            ..
-        } = &mut self.shell
-        {
-            vault.set_content_width(content_width);
         }
     }
 
@@ -207,51 +237,103 @@ impl cosmic::Application for App {
             _ => Subscription::none(),
         };
 
-        if !self.has_tray {
-            return screen;
-        }
+        let mut subscriptions = vec![screen];
 
         // The header bar's close button arrives through `on_app_exit`, but a
         // close from the compositor is a plain window event once the window is
-        // no longer allowed to act on one by itself.
-        let close = event::listen_with(|event, _, _| {
-            matches!(event, Event::Window(window::Event::CloseRequested))
-                .then_some(Message::HideWindow)
-        });
+        // no longer allowed to act on one by itself. Focus is read the same
+        // way; whether losing it locks is decided in `update`, because
+        // `listen_with` takes a bare `fn` with nothing captured.
+        subscriptions.push(event::listen_with(|event, _, _| match event {
+            Event::Window(window::Event::CloseRequested) => Some(Message::CloseIntent),
+            Event::Window(window::Event::Unfocused) => Some(Message::Unfocused),
+            _ => None,
+        }));
 
-        Subscription::batch([screen, close, tray::subscription().map(Message::Tray)])
+        if self.has_tray {
+            subscriptions.push(tray::subscription().map(Message::Tray));
+        }
+
+        // Idle is measured from discrete input rather than from the pointer
+        // crossing the window: a mouse moved by a cat is not someone reading
+        // their vault, and it would cost a redraw per motion event to believe
+        // otherwise.
+        if self.settings.auto_lock_minutes > 0 && self.is_unlocked() {
+            subscriptions.push(event::listen_with(|event, _, _| match event {
+                Event::Keyboard(keyboard::Event::KeyPressed { .. })
+                | Event::Mouse(mouse::Event::ButtonPressed(_))
+                | Event::Mouse(mouse::Event::WheelScrolled { .. }) => Some(Message::Activity),
+                _ => None,
+            }));
+            subscriptions.push(cosmic::iced::time::every(IDLE_TICK).map(|_| Message::IdleTick));
+        }
+
+        Subscription::batch(subscriptions)
     }
 
     fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
-        // Effects that leave the app are the shell's, whoever asked for them.
+        // Effects that leave the app, and the window itself, are the shell's —
+        // whoever asked for them.
         match message {
-            Message::Copy(value) => return cosmic::iced::clipboard::write(value),
+            Message::Copy(value) => return self.copy(value),
             Message::OpenUrl(url) => {
                 if let Err(err) = open::that_detached(&url) {
-                    eprintln!("could not open the browser: {err}");
+                    eprintln!("could not open: {err}");
                 }
                 return Task::none();
             }
-            Message::HideWindow => return self.hide_window(),
+            Message::CloseIntent => {
+                return if self.has_tray && self.settings.close_to_tray {
+                    self.hide_window()
+                } else {
+                    self.quit()
+                };
+            }
             Message::WindowClosed => {
                 self.window_open = false;
                 return Task::none();
             }
-            Message::Tray(tray::Command::Show) => return self.show_window(),
-            Message::Tray(tray::Command::Quit) => return cosmic::iced::exit(),
-            Message::Tray(tray::Command::Lock) => {
-                // Only the open vault holds anything worth locking; the other
-                // screens have nothing to take away.
-                if let Shell::Ready {
-                    session,
-                    screen: screen @ Screen::Vault(_),
-                } = &mut self.shell
-                {
-                    session.lock();
-                    *screen = Screen::Master(master::State::new(master::Mode::Unlock, None));
-                }
+            Message::Unfocused => {
+                return if self.settings.lock_on_focus_loss {
+                    self.lock()
+                } else {
+                    Task::none()
+                };
+            }
+            Message::Activity => {
+                self.last_activity = Instant::now();
                 return Task::none();
             }
+            Message::IdleTick => {
+                let idle = Duration::from_secs(u64::from(self.settings.auto_lock_minutes) * 60);
+                return if self.last_activity.elapsed() >= idle {
+                    self.lock()
+                } else {
+                    Task::none()
+                };
+            }
+            Message::ClipboardExpired(generation) => {
+                // A newer copy has replaced the one this timer was started for.
+                if generation != self.clipboard.1 {
+                    return Task::none();
+                }
+                return self.clear_clipboard();
+            }
+            Message::ClipboardRead(current) => {
+                return if current.as_deref() == Some(self.clipboard.0.as_str()) {
+                    self.wipe_clipboard()
+                } else {
+                    Task::none()
+                };
+            }
+            Message::OpenSettings => return self.open_settings(),
+            Message::Tray(tray::Command::Show) => return self.show_window(),
+            Message::Tray(tray::Command::Settings) => {
+                return Task::batch([self.show_window(), self.open_settings()]);
+            }
+            Message::Tray(tray::Command::Quit) => return self.quit(),
+            Message::Tray(tray::Command::Lock) => return self.lock(),
+            Message::Settings(message) => return self.update_settings(message),
             _ => {}
         }
 
@@ -259,6 +341,7 @@ impl cosmic::Application for App {
         // here and applied once that borrow ends.
         let mut lost_session = None;
         let content_width = self.content_width();
+        let reveal_seconds = self.settings.auto_hide_reveal_seconds;
 
         let task = {
             let Shell::Ready { session, screen } = &mut self.shell else {
@@ -332,6 +415,7 @@ impl cosmic::Application for App {
                         master::Outcome::Opened { page, sync_error } => {
                             let mut vault = vault::State::new(page, sync_error);
                             vault.set_content_width(content_width);
+                            vault.set_reveal_seconds(reveal_seconds);
                             *screen = Screen::Vault(Box::new(vault));
                             Task::none()
                         }
@@ -366,19 +450,192 @@ impl cosmic::Application for App {
     }
 
     fn view(&self) -> Element<'_, Self::Message> {
-        match &self.shell {
-            Shell::Blocked(reason) => blocked_view(reason),
-            Shell::Ready { screen, .. } => match screen {
-                Screen::Welcome => welcome::view().map(Message::Welcome),
-                Screen::Connect(state) => state.view().map(Message::Connect),
-                Screen::Master(state) => state.view().map(Message::Master),
-                Screen::Vault(state) => state.view().map(Message::Vault),
+        match self.settings_screen.as_ref() {
+            Some(settings) => settings.view().map(Message::Settings),
+            None => match &self.shell {
+                Shell::Blocked(reason) => blocked_view(reason),
+                Shell::Ready { screen, .. } => match screen {
+                    Screen::Welcome => welcome::view().map(Message::Welcome),
+                    Screen::Connect(state) => state.view().map(Message::Connect),
+                    Screen::Master(state) => state.view().map(Message::Master),
+                    Screen::Vault(state) => state.view().map(Message::Vault),
+                },
             },
         }
     }
 }
 
 impl App {
+    /// Whether there is anything worth locking. The other screens hold nothing.
+    fn is_unlocked(&self) -> bool {
+        matches!(
+            &self.shell,
+            Shell::Ready {
+                screen: Screen::Vault(_),
+                ..
+            }
+        )
+    }
+
+    fn open_settings(&mut self) -> Task<Message> {
+        if self.settings_screen.is_some() {
+            return Task::none();
+        }
+        let storages = match &self.shell {
+            Shell::Ready { session, .. } => local::storages(&session.facade()).unwrap_or_default(),
+            Shell::Blocked(_) => Vec::new(),
+        };
+        self.settings_screen = Some(Box::new(settings::State::new(
+            self.settings.clone(),
+            storages,
+        )));
+        Task::none()
+    }
+
+    fn update_settings(&mut self, message: settings::Message) -> Task<Message> {
+        let Some(state) = self.settings_screen.as_mut() else {
+            return Task::none();
+        };
+        match state.update(message) {
+            settings::Outcome::None => Task::none(),
+            settings::Outcome::Task(task) => lift(task, Message::Settings),
+            settings::Outcome::OpenUrl(url) => cosmic::task::message(Message::OpenUrl(url)),
+            settings::Outcome::Close => {
+                self.settings_screen = None;
+                Task::none()
+            }
+            settings::Outcome::AddServer => {
+                self.settings_screen = None;
+                if let Shell::Ready { screen, .. } = &mut self.shell {
+                    *screen = Screen::Connect(Box::default());
+                }
+                Task::none()
+            }
+            settings::Outcome::Changed(change) => self.change_setting(change),
+            settings::Outcome::Sync(storage_id) => {
+                let Shell::Ready { session, .. } = &self.shell else {
+                    return Task::none();
+                };
+                let facade = session.facade();
+                lift(
+                    cosmic::task::future(async move {
+                        settings::Message::Synced(
+                            backend::off_thread(move || local::sync(&facade, Some(storage_id)))
+                                .await,
+                        )
+                    }),
+                    Message::Settings,
+                )
+            }
+        }
+    }
+
+    /// A change lands in three places: the shell's copy, the file, and the
+    /// screen that drew the control — which is told rather than left to assume,
+    /// so a write that failed does not show as one that worked.
+    fn change_setting(&mut self, change: Change) -> Task<Message> {
+        self.settings.set(change);
+        if matches!(change, Change::Language(_)) {
+            i18n::set_language(self.settings.language.as_deref());
+            tray::refresh();
+        }
+        if let Err(err) = self.settings.save() {
+            eprintln!("could not save the settings: {err}");
+        }
+        if let Some(state) = self.settings_screen.as_mut() {
+            state.settings_changed(self.settings.clone());
+        }
+        if let Shell::Ready {
+            screen: Screen::Vault(vault),
+            ..
+        } = &mut self.shell
+        {
+            vault.set_reveal_seconds(self.settings.auto_hide_reveal_seconds);
+        }
+        Task::none()
+    }
+
+    /// Locks the vault and shows the unlock screen, taking the clipboard with
+    /// it if that is what the settings ask for.
+    fn lock(&mut self) -> Task<Message> {
+        let Shell::Ready {
+            session,
+            screen: screen @ Screen::Vault(_),
+        } = &mut self.shell
+        else {
+            return Task::none();
+        };
+        session.lock();
+        *screen = Screen::Master(master::State::new(master::Mode::Unlock, None));
+        self.settings_screen = None;
+
+        if self.settings.clipboard_clear_on_lock {
+            self.clear_clipboard()
+        } else {
+            Task::none()
+        }
+    }
+
+    fn quit(&mut self) -> Task<Message> {
+        if self.settings.clipboard_clear_on_exit {
+            // The clear has to land before the runtime stops, so it is chained
+            // rather than left as a task the exit would outrun.
+            return self.wipe_clipboard().chain(cosmic::iced::exit());
+        }
+        cosmic::iced::exit()
+    }
+
+    /// Puts a secret on the clipboard and starts its clock. There is no
+    /// cancelling a task already handed to the runtime, so a later copy is
+    /// recognised by the count rather than by stopping the earlier timer.
+    fn copy(&mut self, value: String) -> Task<Message> {
+        self.clipboard.0 = value.clone();
+        self.clipboard.1 += 1;
+        let generation = self.clipboard.1;
+        let write = cosmic::iced::clipboard::write(value);
+
+        let seconds = u64::from(self.settings.clipboard_clear_seconds);
+        if seconds == 0 {
+            return write;
+        }
+        Task::batch([
+            write,
+            cosmic::task::future(async move {
+                tokio::time::sleep(Duration::from_secs(seconds)).await;
+                Message::ClipboardExpired(generation)
+            }),
+        ])
+    }
+
+    /// Takes back what we put there — but only ours, if the settings say so.
+    /// Reading first costs a round trip through the runtime, which is why the
+    /// answer comes back as a message.
+    fn clear_clipboard(&mut self) -> Task<Message> {
+        if self.clipboard.0.is_empty() {
+            return Task::none();
+        }
+        if self.settings.clipboard_clear_if_unchanged {
+            return cosmic::iced::clipboard::read()
+                .map(|value| cosmic::Action::App(Message::ClipboardRead(value)));
+        }
+        self.wipe_clipboard()
+    }
+
+    fn wipe_clipboard(&mut self) -> Task<Message> {
+        self.clipboard.0.clear();
+        cosmic::iced::clipboard::write(String::new())
+    }
+
+    /// What is left of the window once the nav bar has taken its share — which
+    /// is nothing when the user has collapsed it from the header bar.
+    fn content_width(&self) -> f32 {
+        if self.core.nav_bar_active() {
+            self.window_width - NAV_WIDTH
+        } else {
+            self.window_width
+        }
+    }
+
     /// Into the tray. There is no hiding a window on Wayland — winit says as
     /// much — so this destroys it. Nothing is lost with it: every bit of state
     /// the app has, including the open [`Session`], lives in `App`.
@@ -389,7 +646,12 @@ impl App {
         let Some(id) = self.core.main_window_id().filter(|_| self.window_open) else {
             return Task::none();
         };
-        window::close(id)
+        let lock = if self.settings.lock_on_hidden {
+            self.lock()
+        } else {
+            Task::none()
+        };
+        Task::batch([lock, window::close(id)])
     }
 
     /// Back out of it, into a new window that the shell then treats as its main
@@ -405,16 +667,6 @@ impl App {
         self.window_open = true;
         let title = self.set_window_title("zann".to_string(), id);
         Task::batch([task.discard(), title])
-    }
-
-    /// What is left of the window once the nav bar has taken its share — which
-    /// is nothing when the user has collapsed it from the header bar.
-    fn content_width(&self) -> f32 {
-        if self.core.nav_bar_active() {
-            self.window_width - NAV_WIDTH
-        } else {
-            self.window_width
-        }
     }
 }
 

--- a/apps/cosmic/src/screens/mod.rs
+++ b/apps/cosmic/src/screens/mod.rs
@@ -6,6 +6,7 @@
 pub mod connect;
 pub mod detail;
 pub mod master;
+pub mod settings;
 pub mod vault;
 pub mod welcome;
 

--- a/apps/cosmic/src/screens/settings.rs
+++ b/apps/cosmic/src/screens/settings.rs
@@ -1,0 +1,406 @@
+//! The settings screen.
+//!
+//! Sections, names and choices are the desktop app's settings modal, in the
+//! COSMIC idiom: `widget::settings::section` rows, so it reads like the system
+//! settings rather than like a modal borrowed from a web app.
+//!
+//! Two of the desktop's five tabs are missing, and deliberately. Backups sits
+//! on `backup_export_file` / `backup_import_file`, which `zann-ffi` answers
+//! with `Unimplemented` — the desktop does that work on its own side. And the
+//! keystore block under Security is inert on Linux for both clients:
+//! `zann-keystore` only implements macOS, so its status is `supported: false`
+//! here and every control under it would be greyed out.
+
+use cosmic::iced::{Alignment, Length};
+use cosmic::{theme, widget, Element};
+use zann_ffi::StorageSummaryFfi;
+
+use crate::i18n::t;
+use crate::settings::{Change, Settings};
+use zann_ui_core::LANGUAGES;
+
+/// Minutes, paired with what to call them. The desktop app's choices.
+const AUTO_LOCK: &[(u32, &str)] = &[
+    (0, "Never"),
+    (1, "1 minute"),
+    (5, "5 minutes"),
+    (10, "10 minutes"),
+    (30, "30 minutes"),
+    (60, "1 hour"),
+];
+
+const CLIPBOARD: &[(u32, &str)] = &[
+    (0, "Never"),
+    (15, "15 seconds"),
+    (30, "30 seconds"),
+    (60, "60 seconds"),
+    (120, "2 minutes"),
+    (300, "5 minutes"),
+];
+
+const REVEAL: &[(u32, &str)] = &[
+    (0, "Never"),
+    (10, "10 seconds"),
+    (30, "30 seconds"),
+    (60, "60 seconds"),
+];
+
+const DOCS_URL: &str = "https://docs.zann.app";
+const SOURCE_URL: &str = "https://github.com/constxife/zann";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Section {
+    General,
+    Security,
+    Accounts,
+    About,
+}
+
+impl Section {
+    const ALL: &'static [Self] = &[Self::General, Self::Security, Self::Accounts, Self::About];
+
+    fn label(self) -> String {
+        t(match self {
+            Self::General => "settings.tabs.general",
+            Self::Security => "settings.tabs.security",
+            Self::Accounts => "settings.tabs.accounts",
+            Self::About => "settings.tabs.about",
+        })
+    }
+
+    fn icon(self) -> &'static str {
+        match self {
+            Self::General => "preferences-system-symbolic",
+            Self::Security => "channel-secure-symbolic",
+            Self::Accounts => "system-users-symbolic",
+            Self::About => "help-about-symbolic",
+        }
+    }
+}
+
+pub struct State {
+    section: Section,
+    settings: Settings,
+    /// Servers and local vaults, for the Accounts section.
+    storages: Vec<StorageSummaryFfi>,
+    error: Option<String>,
+    syncing: bool,
+}
+
+#[derive(Clone, Debug)]
+pub enum Message {
+    Select(Section),
+    Set(Change),
+    SyncNow(String),
+    Synced(Result<(), String>),
+    AddServer,
+    OpenUrl(String),
+    Close,
+}
+
+pub enum Outcome {
+    None,
+    Task(cosmic::iced::Task<Message>),
+    /// A setting changed; the shell owns persisting it and acting on it.
+    Changed(Change),
+    /// The vault is the shell's, so a sync is asked for rather than run here.
+    Sync(String),
+    /// Effects that leave the app, which are the shell's.
+    OpenUrl(String),
+    /// Straight to the connect screen, the way the desktop's "Add server" does.
+    AddServer,
+    Close,
+}
+
+impl State {
+    pub fn new(settings: Settings, storages: Vec<StorageSummaryFfi>) -> Self {
+        Self {
+            section: Section::General,
+            settings,
+            storages,
+            error: None,
+            syncing: false,
+        }
+    }
+
+    /// The shell persists the change, so the screen is told what stuck rather
+    /// than assuming its own copy is authoritative.
+    pub fn settings_changed(&mut self, settings: Settings) {
+        self.settings = settings;
+    }
+
+    pub fn update(&mut self, message: Message) -> Outcome {
+        match message {
+            Message::Select(section) => {
+                self.section = section;
+                Outcome::None
+            }
+            Message::Set(change) => Outcome::Changed(change),
+            Message::SyncNow(storage_id) => {
+                if self.syncing {
+                    return Outcome::None;
+                }
+                self.syncing = true;
+                self.error = None;
+                Outcome::Sync(storage_id)
+            }
+            Message::Synced(result) => {
+                self.syncing = false;
+                self.error = result.err();
+                Outcome::None
+            }
+            Message::AddServer => Outcome::AddServer,
+            Message::OpenUrl(url) => Outcome::OpenUrl(url),
+            Message::Close => Outcome::Close,
+        }
+    }
+
+    pub fn view(&self) -> Element<'_, Message> {
+        let spacing = theme::spacing();
+
+        let mut sections =
+            widget::column::with_capacity(Section::ALL.len()).spacing(spacing.space_xxs);
+        for section in Section::ALL {
+            sections = sections.push(
+                widget::button::custom(
+                    widget::row::with_capacity(2)
+                        .push(widget::icon::from_name(section.icon()).size(16).icon())
+                        .push(widget::text::body(section.label()))
+                        .spacing(spacing.space_xs)
+                        .align_y(Alignment::Center),
+                )
+                .class(if *section == self.section {
+                    theme::Button::Suggested
+                } else {
+                    theme::Button::Text
+                })
+                .width(Length::Fill)
+                .on_press(Message::Select(*section)),
+            );
+        }
+
+        let body = match self.section {
+            Section::General => self.general(),
+            Section::Security => self.security(),
+            Section::Accounts => self.accounts(),
+            Section::About => self.about(),
+        };
+
+        let header = widget::row::with_capacity(2)
+            .push(widget::text::title3(t("settings.title")).width(Length::Fill))
+            .push(
+                widget::button::icon(widget::icon::from_name("window-close-symbolic"))
+                    .on_press(Message::Close),
+            )
+            .align_y(Alignment::Center);
+
+        let columns = widget::row::with_capacity(3)
+            .push(widget::container(sections).width(Length::Fixed(180.0)))
+            .push(widget::divider::vertical::default())
+            .push(
+                widget::scrollable(body)
+                    .width(Length::Fill)
+                    .height(Length::Fill),
+            )
+            .spacing(spacing.space_s)
+            .height(Length::Fill);
+
+        widget::column::with_capacity(2)
+            .push(header)
+            .push(columns)
+            .spacing(spacing.space_s)
+            .padding(spacing.space_s)
+            .into()
+    }
+
+    fn general(&self) -> Element<'_, Message> {
+        // The first entry is "follow the environment", which is what an unset
+        // preference means, so its index is one ahead of the language list.
+        let mut languages = Vec::with_capacity(LANGUAGES.len() + 1);
+        languages.push(t("settings.general.languageSystem"));
+        languages.extend(LANGUAGES.iter().map(|(_, name)| (*name).to_string()));
+        let selected = self.settings.language.as_deref().map_or(0, |chosen| {
+            LANGUAGES
+                .iter()
+                .position(|(tag, _)| *tag == chosen)
+                .map_or(0, |index| index + 1)
+        });
+
+        let appearance = widget::settings::section()
+            .title(t("settings.general.appearance"))
+            .add(
+                widget::settings::item::builder(t("settings.general.language")).control(
+                    widget::dropdown(languages, Some(selected), |index| {
+                        Message::Set(Change::Language(
+                            index.checked_sub(1).map(|index| LANGUAGES[index].0),
+                        ))
+                    }),
+                ),
+            );
+
+        let behavior = widget::settings::section()
+            .title(t("settings.general.behavior"))
+            .add(
+                widget::settings::item::builder(t("settings.general.closeToTray"))
+                    .description(t("settings.general.closeToTrayHelp"))
+                    .toggler(self.settings.close_to_tray, |value| {
+                        Message::Set(Change::CloseToTray(value))
+                    }),
+            );
+
+        widget::settings::view_column(vec![appearance.into(), behavior.into()]).into()
+    }
+
+    fn security(&self) -> Element<'_, Message> {
+        let settings = &self.settings;
+
+        let auto_lock = widget::settings::section()
+            .title(t("settings.autolock"))
+            .add(
+                widget::settings::item::builder(t("settings.autolockAfter")).control(choice(
+                    AUTO_LOCK,
+                    settings.auto_lock_minutes,
+                    |value| Message::Set(Change::AutoLockMinutes(value)),
+                )),
+            )
+            .add(
+                widget::settings::item::builder(t("settings.lockOnHidden"))
+                    .toggler(settings.lock_on_hidden, |value| {
+                        Message::Set(Change::LockOnHidden(value))
+                    }),
+            )
+            .add(
+                widget::settings::item::builder(t("settings.lockOnFocusLoss"))
+                    .toggler(settings.lock_on_focus_loss, |value| {
+                        Message::Set(Change::LockOnFocusLoss(value))
+                    }),
+            );
+
+        let clipboard = widget::settings::section()
+            .title(t("settings.clipboard"))
+            .add(
+                widget::settings::item::builder(t("settings.clipboardAfter")).control(choice(
+                    CLIPBOARD,
+                    settings.clipboard_clear_seconds,
+                    |value| Message::Set(Change::ClipboardSeconds(value)),
+                )),
+            )
+            .add(
+                widget::settings::item::builder(t("settings.clipboardOnLock"))
+                    .toggler(settings.clipboard_clear_on_lock, |value| {
+                        Message::Set(Change::ClipboardOnLock(value))
+                    }),
+            )
+            .add(
+                widget::settings::item::builder(t("settings.clipboardOnExit"))
+                    .toggler(settings.clipboard_clear_on_exit, |value| {
+                        Message::Set(Change::ClipboardOnExit(value))
+                    }),
+            )
+            .add(
+                widget::settings::item::builder(t("settings.clipboardIfUnchanged"))
+                    .toggler(settings.clipboard_clear_if_unchanged, |value| {
+                        Message::Set(Change::ClipboardIfUnchanged(value))
+                    }),
+            );
+
+        let reveal = widget::settings::section().title(t("settings.reveal")).add(
+            widget::settings::item::builder(t("settings.revealAfter")).control(choice(
+                REVEAL,
+                settings.auto_hide_reveal_seconds,
+                |value| Message::Set(Change::AutoHideRevealSeconds(value)),
+            )),
+        );
+
+        widget::settings::view_column(vec![auto_lock.into(), clipboard.into(), reveal.into()])
+            .into()
+    }
+
+    fn accounts(&self) -> Element<'_, Message> {
+        let spacing = theme::spacing();
+        let mut servers =
+            widget::settings::section().title(t("settings.accounts.connectedServers"));
+
+        if self.storages.is_empty() {
+            servers = servers.add(widget::text::body(t("settings.accounts.noServers")));
+        }
+        for storage in &self.storages {
+            let mut sync = widget::button::standard(t("settings.accounts.syncNow"));
+            if !self.syncing {
+                sync = sync.on_press(Message::SyncNow(storage.id.clone()));
+            }
+            servers = servers.add(
+                widget::settings::item::builder(storage.name.clone())
+                    .description(storage.id.clone())
+                    .control(sync),
+            );
+        }
+
+        servers = servers.add(
+            widget::settings::item::builder(t("storage.addServer"))
+                .control(widget::button::standard(t("common.create")).on_press(Message::AddServer)),
+        );
+
+        let mut column = widget::settings::view_column(vec![servers.into()]);
+        if let Some(error) = self.error.as_ref() {
+            column = column.push(widget::text::caption(error.clone()));
+        }
+
+        column.spacing(spacing.space_s).into()
+    }
+
+    fn about(&self) -> Element<'_, Message> {
+        let data = crate::backend::client_root(&crate::backend::default_db_url());
+        let logs = data.join("logs");
+
+        let app = widget::settings::section()
+            .title(t("app.title"))
+            .add(
+                widget::settings::item::builder(t("settings.about.version"))
+                    .control(widget::text::monotext(env!("CARGO_PKG_VERSION"))),
+            )
+            .add(
+                widget::settings::item::builder(t("settings.about.openDataFolder"))
+                    .description(data.display().to_string())
+                    .control(
+                        widget::button::standard(t("common.open"))
+                            .on_press(Message::OpenUrl(data.display().to_string())),
+                    ),
+            )
+            .add(
+                widget::settings::item::builder(t("settings.about.viewLogs")).control(
+                    widget::button::standard(t("common.open"))
+                        .on_press(Message::OpenUrl(logs.display().to_string())),
+                ),
+            );
+
+        let links = widget::settings::section()
+            .title(t("settings.about.links"))
+            .add(
+                widget::settings::item::builder(t("settings.about.documentation")).control(
+                    widget::button::standard(t("common.open"))
+                        .on_press(Message::OpenUrl(DOCS_URL.to_string())),
+                ),
+            )
+            .add(
+                widget::settings::item::builder(t("settings.about.sourceCode")).control(
+                    widget::button::standard(t("common.open"))
+                        .on_press(Message::OpenUrl(SOURCE_URL.to_string())),
+                ),
+            );
+
+        widget::settings::view_column(vec![app.into(), links.into()]).into()
+    }
+}
+
+/// A dropdown over `(value, label)` pairs. An unknown stored value shows
+/// nothing selected rather than silently becoming one of the choices.
+fn choice(
+    options: &'static [(u32, &'static str)],
+    selected: u32,
+    on_select: fn(u32) -> Message,
+) -> Element<'static, Message> {
+    let labels: Vec<&'static str> = options.iter().map(|(_, label)| *label).collect();
+    let index = options.iter().position(|(value, _)| *value == selected);
+    widget::dropdown(labels, index, move |index| on_select(options[index].0)).into()
+}

--- a/apps/cosmic/src/screens/vault.rs
+++ b/apps/cosmic/src/screens/vault.rs
@@ -77,6 +77,11 @@ pub struct State {
     detail: Option<Detail>,
     busy: bool,
     error: Option<String>,
+    /// How long a revealed field stays revealed, `0` for as long as it likes.
+    reveal_seconds: u32,
+    /// Bumped on every reveal, so a hide scheduled for an earlier one does not
+    /// take away a field the user has only just opened.
+    reveal_generation: u64,
     /// The width the user dragged the list to. Kept as their intent even while
     /// a narrow window forces a smaller one, so it returns when the room does.
     list_width: f32,
@@ -94,6 +99,9 @@ pub enum Message {
     Select(String),
     Loaded(Result<Detail, String>),
     Detail(detail::Message),
+    /// A revealed field's time is up, for the reveal that was current when the
+    /// clock started.
+    HideRevealed(u64),
     CloseDetail,
     Lock,
     Tick,
@@ -122,6 +130,8 @@ impl State {
             detail: None,
             busy: false,
             error: sync_error.map(|err| t_args("items.syncFailed", &[("error", &err)])),
+            reveal_seconds: 0,
+            reveal_generation: 0,
             list_width: layout::LIST_DEFAULT,
             // Enough for the default split until the shell reports the window.
             content_width: layout::LIST_DEFAULT + layout::HANDLE + layout::DETAIL_MIN,
@@ -140,6 +150,16 @@ impl State {
     /// the nav bar left for these two columns.
     pub fn set_content_width(&mut self, width: f32) {
         self.content_width = width;
+    }
+
+    /// The shell owns the settings, so it is the one that says how long a
+    /// revealed field may stay that way.
+    pub fn set_reveal_seconds(&mut self, seconds: u32) {
+        self.reveal_seconds = seconds;
+        if seconds == 0 {
+            // Nothing left to hide; let any timer already out there go stale.
+            self.reveal_generation += 1;
+        }
     }
 
     /// Where the splitter currently sits, held to what the window allows.
@@ -248,9 +268,34 @@ impl State {
 
             Message::Detail(detail::Message::Copy(value)) => return Outcome::Copy(value),
 
-            Message::Detail(message) => {
+            Message::Detail(detail::Message::ToggleReveal(index)) => {
+                let Some(detail) = self.detail.as_mut() else {
+                    return Outcome::None;
+                };
+                detail.update(detail::Message::ToggleReveal(index));
+
+                let revealed = detail.fields.get(index).is_some_and(|field| field.revealed);
+                if !revealed || self.reveal_seconds == 0 {
+                    return Outcome::None;
+                }
+                self.reveal_generation += 1;
+                let generation = self.reveal_generation;
+                let seconds = u64::from(self.reveal_seconds);
+                return Outcome::Task(cosmic::task::future(async move {
+                    tokio::time::sleep(Duration::from_secs(seconds)).await;
+                    Message::HideRevealed(generation)
+                }));
+            }
+
+            Message::HideRevealed(generation) => {
+                // A later reveal has already replaced the one this was for.
+                if generation != self.reveal_generation {
+                    return Outcome::None;
+                }
                 if let Some(detail) = self.detail.as_mut() {
-                    detail.update(message);
+                    for field in &mut detail.fields {
+                        field.revealed = false;
+                    }
                 }
             }
 

--- a/apps/cosmic/src/settings.rs
+++ b/apps/cosmic/src/settings.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+
+//! The settings the app keeps between runs.
+//!
+//! The names and the defaults are the desktop app's `DesktopSettings`, so that
+//! "auto-lock after 10 minutes" means the same thing in both clients and a
+//! reader moving between them is not asked to learn a second vocabulary.
+//!
+//! The file is not shared, though. `desktop.json` carries a wrapped master key
+//! and a biometry backup that this app has no way to produce, and a round trip
+//! through a struct without those fields would quietly drop them — so this one
+//! keeps its own, next to the database like the rest of the client state.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::backend::{client_root, default_db_url};
+
+const FILENAME: &str = "cosmic.json";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Settings {
+    /// `None` is whatever the environment asks for, which is what an unset
+    /// preference means in the desktop app too.
+    pub language: Option<String>,
+    pub close_to_tray: bool,
+    /// Minutes of no input before the vault locks itself. `0` is never.
+    pub auto_lock_minutes: u32,
+    pub lock_on_hidden: bool,
+    pub lock_on_focus_loss: bool,
+    /// Seconds a copied secret stays on the clipboard. `0` is never.
+    pub clipboard_clear_seconds: u32,
+    pub clipboard_clear_on_lock: bool,
+    pub clipboard_clear_on_exit: bool,
+    /// Only clear if nothing else has written to the clipboard since — taking
+    /// away what someone copied afterwards would be worse than leaving ours.
+    pub clipboard_clear_if_unchanged: bool,
+    /// Seconds a revealed field stays revealed. `0` is never.
+    pub auto_hide_reveal_seconds: u32,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            language: None,
+            close_to_tray: true,
+            auto_lock_minutes: 10,
+            lock_on_hidden: false,
+            lock_on_focus_loss: false,
+            clipboard_clear_seconds: 60,
+            clipboard_clear_on_lock: true,
+            clipboard_clear_on_exit: true,
+            clipboard_clear_if_unchanged: true,
+            auto_hide_reveal_seconds: 20,
+        }
+    }
+}
+
+/// One field, so the screen reports what the user changed rather than handing
+/// back a whole [`Settings`] the shell would have to diff.
+#[derive(Clone, Copy, Debug)]
+pub enum Change {
+    Language(Option<&'static str>),
+    CloseToTray(bool),
+    AutoLockMinutes(u32),
+    LockOnHidden(bool),
+    LockOnFocusLoss(bool),
+    ClipboardSeconds(u32),
+    ClipboardOnLock(bool),
+    ClipboardOnExit(bool),
+    ClipboardIfUnchanged(bool),
+    AutoHideRevealSeconds(u32),
+}
+
+impl Settings {
+    /// Anything unreadable falls back to the defaults rather than blocking the
+    /// app: settings are a preference, not the vault.
+    pub fn load() -> Self {
+        std::fs::read_to_string(path())
+            .ok()
+            .and_then(|text| serde_json::from_str(&text).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self) -> Result<(), String> {
+        let path = path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+        }
+        let text = serde_json::to_string_pretty(self).map_err(|err| err.to_string())?;
+        std::fs::write(path, text).map_err(|err| err.to_string())
+    }
+
+    pub fn set(&mut self, change: Change) {
+        match change {
+            Change::Language(value) => self.language = value.map(str::to_string),
+            Change::CloseToTray(value) => self.close_to_tray = value,
+            Change::AutoLockMinutes(value) => self.auto_lock_minutes = value,
+            Change::LockOnHidden(value) => self.lock_on_hidden = value,
+            Change::LockOnFocusLoss(value) => self.lock_on_focus_loss = value,
+            Change::ClipboardSeconds(value) => self.clipboard_clear_seconds = value,
+            Change::ClipboardOnLock(value) => self.clipboard_clear_on_lock = value,
+            Change::ClipboardOnExit(value) => self.clipboard_clear_on_exit = value,
+            Change::ClipboardIfUnchanged(value) => self.clipboard_clear_if_unchanged = value,
+            Change::AutoHideRevealSeconds(value) => self.auto_hide_reveal_seconds = value,
+        }
+    }
+}
+
+pub fn path() -> PathBuf {
+    client_root(&default_db_url()).join(FILENAME)
+}

--- a/apps/cosmic/src/tray.rs
+++ b/apps/cosmic/src/tray.rs
@@ -29,6 +29,8 @@ use crate::i18n::t;
 pub enum Command {
     /// Put the window back, or focus the one that is already there.
     Show,
+    /// The window, with the settings on top of it.
+    Settings,
     Lock,
     Quit,
 }
@@ -83,6 +85,7 @@ impl ksni::Tray for Tray {
     fn menu(&self) -> Vec<MenuItem<Self>> {
         vec![
             self.item("common.show", Command::Show),
+            self.item("common.settings", Command::Settings),
             MenuItem::Separator,
             self.item("common.lock", Command::Lock),
             self.item("common.quit", Command::Quit),
@@ -113,6 +116,15 @@ pub fn start(app_id: &'static str, title: &'static str) -> bool {
     // Both only fail if `start` ran twice, which would leave the second tray
     // talking to a channel nobody reads.
     COMMANDS.set(Mutex::new(Some(receiver))).is_ok() && HANDLE.set(handle).is_ok()
+}
+
+/// Redraws the menu. Its labels come from the catalogue, and the host caches
+/// what it was last given, so a language change has to be pushed rather than
+/// waited for.
+pub fn refresh() {
+    if let Some(handle) = HANDLE.get() {
+        handle.update(|_| {});
+    }
 }
 
 /// The commands the tray has raised. Empty, and cheap, when there is no tray.

--- a/apps/cosmic/tests/flows.rs
+++ b/apps/cosmic/tests/flows.rs
@@ -4,7 +4,7 @@
 
 use zann_cosmic::backend::local;
 use zann_cosmic::backend::remote::{LoginOutcome, Method, ServerProbe};
-use zann_cosmic::screens::detail::Detail;
+use zann_cosmic::screens::detail::{self, Detail};
 use zann_cosmic::screens::{connect, master, vault};
 use zann_cosmic::session::Session;
 use zann_ffi::ItemUpdate;
@@ -276,6 +276,86 @@ fn walk_sources(root: &str) -> Vec<std::path::PathBuf> {
         }
     }
     found
+}
+
+#[test]
+fn a_revealed_field_hides_itself_once_the_setting_says_to() {
+    let (_dir, session) = vault_with_items();
+    let facade = session.facade();
+    let page = local::items(&facade, None).expect("items");
+    let login = page
+        .items
+        .iter()
+        .find(|item| item.type_id == "login")
+        .expect("login in the page");
+    let detail = Detail::parse(local::item_get(&facade, login.id.clone()).expect("item_get"))
+        .expect("parse");
+    let password = detail
+        .fields
+        .iter()
+        .position(|field| field.key == "password")
+        .expect("password field");
+
+    let mut state = vault::State::new(page, None);
+    state.update(vault::Message::Loaded(Ok(detail)), &session);
+
+    // Off by default, so revealing schedules nothing to take it away.
+    let outcome = state.update(
+        vault::Message::Detail(detail::Message::ToggleReveal(password)),
+        &session,
+    );
+    assert!(matches!(outcome, vault::Outcome::None));
+    assert!(state.detail().expect("detail").fields[password].revealed);
+
+    state.set_reveal_seconds(20);
+    let outcome = state.update(
+        vault::Message::Detail(detail::Message::ToggleReveal(password)),
+        &session,
+    );
+    assert!(
+        matches!(outcome, vault::Outcome::None),
+        "hiding again waits for nothing"
+    );
+
+    let outcome = state.update(
+        vault::Message::Detail(detail::Message::ToggleReveal(password)),
+        &session,
+    );
+    assert!(
+        matches!(outcome, vault::Outcome::Task(_)),
+        "revealing starts the clock"
+    );
+
+    // A stale timer belongs to an earlier reveal and leaves this one alone.
+    // Only the third toggle started a clock, so that clock is the first one.
+    state.update(vault::Message::HideRevealed(0), &session);
+    assert!(state.detail().expect("detail").fields[password].revealed);
+
+    state.update(vault::Message::HideRevealed(1), &session);
+    assert!(!state.detail().expect("detail").fields[password].revealed);
+}
+
+#[test]
+fn settings_round_trip_through_a_file() {
+    let mut settings = zann_cosmic::settings::Settings::default();
+    assert_eq!(settings.auto_lock_minutes, 10);
+    assert!(settings.close_to_tray);
+
+    settings.set(zann_cosmic::settings::Change::AutoLockMinutes(30));
+    settings.set(zann_cosmic::settings::Change::CloseToTray(false));
+
+    let text = serde_json::to_string(&settings).expect("serialize");
+    let back: zann_cosmic::settings::Settings = serde_json::from_str(&text).expect("deserialize");
+    assert_eq!(back, settings);
+
+    // A file written by an older build is missing fields, not broken.
+    let partial: zann_cosmic::settings::Settings =
+        serde_json::from_str(r#"{"auto_lock_minutes": 5}"#).expect("partial");
+    assert_eq!(partial.auto_lock_minutes, 5);
+    assert_eq!(
+        partial.clipboard_clear_seconds,
+        zann_cosmic::settings::Settings::default().clipboard_clear_seconds
+    );
 }
 
 #[test]


### PR DESCRIPTION
Same option names and defaults as the desktop's `DesktopSettings`, so "auto-lock after 10 minutes" means the same thing in both clients. Stored in `cosmic.json` beside the database — not shared with `desktop.json`, which holds a wrapped master key and a biometry backup this client cannot produce and would drop on a round trip.

Everything here is wired, not just drawn: close to tray, auto-lock, lock on hidden, lock on focus loss, the four clipboard options, auto-hide reveal, and a language picker.

Two of the desktop's five tabs are missing for a reason rather than for now — Backups sits on ffi calls that answer `Unimplemented`, and the keystore block is inert on Linux for both clients.

Verified: `cargo fmt`, `clippy`, `cargo test` (10). Checked live by planting a non-default `cosmic.json` — all eight controls came up on its values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)