### PR TITLE
feat(cosmic): folders, vault switching and where you left off

### DIFF
--- a/apps/cosmic/README.md
+++ b/apps/cosmic/README.md
@@ -69,6 +69,37 @@ does not produce an `l`.
 Lock stays in the menu while the vault is shut, disabled rather than hidden, so
 the menu does not change shape between screens.
 
+## The sidebar
+
+The desktop app stacks three things in that column: which vault, the categories,
+the folders. libcosmic's nav bar covers only the middle one, and the folders
+cannot simply join the categories in its model — a nav bar has one selection,
+while a folder *narrows* whatever category is showing rather than replacing it,
+the way it does in `useAppItemFilters.ts`.
+
+So `nav_bar` is overridden and the categories keep the stock widget inside it,
+with the vault picker above and the folder tree below. The tree comes from
+`zann_ui_core::build_folder_tree`, which the desktop app already used; the two
+selections stay independent and `ItemFilter` composes them, along with the
+search. The stock widget paints its own background through `into_container`,
+which building it into a column bypasses, so `nav_bar_style` is applied again
+around the whole column.
+
+The vault picker only appears when there is a choice — one vault needs no
+dropdown. Switching is the shell's: it owns the session, so the screen reports
+`Outcome::SwitchVault` rather than reaching for the facade.
+
+## Where the reader left off
+
+`cosmic.json` also keeps the splitter's width, the selected category and the
+selected folder, so the app opens where it was left. Restoring a folder unfolds
+the path down to it, or the selected row would be hidden inside a closed parent.
+
+Two of the desktop's are deliberately not kept: the search query and the
+selected item. Both record what someone went looking for, and neither is worth
+writing to disk to save a click. A place is only written when it actually
+changes, because dragging a splitter reports on every pixel.
+
 ## The three columns
 
 The open vault is the same shape as the Tauri app: nav categories, the item

--- a/apps/cosmic/src/backend/local.rs
+++ b/apps/cosmic/src/backend/local.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use zann_ffi::{
     create_core, AppStatusFfi, CoreFacade, ItemDetail, ItemSummary, ItemsFilter, Page,
-    StorageSummaryFfi,
+    StorageSummaryFfi, VaultSummaryFfi,
 };
 use zann_ui_core::ItemCounts;
 
@@ -89,6 +89,24 @@ pub fn items(facade: &CoreFacade, cursor: Option<String>) -> Result<ItemsPage, S
 
 pub fn item_get(facade: &CoreFacade, id: String) -> Result<ItemDetail, String> {
     facade.item_get(id).map_err(|err| err.to_string())
+}
+
+/// The sealed vaults on the current storage, for the sidebar's picker.
+pub fn vaults(facade: &CoreFacade) -> Vec<VaultSummaryFfi> {
+    facade.list_vaults().unwrap_or_default()
+}
+
+pub fn current_vault(facade: &CoreFacade) -> Option<String> {
+    facade.current_vault_id()
+}
+
+/// Opens another vault and reads its first page. One call rather than two so
+/// the screen is never built against the vault it just left.
+pub fn switch_vault(facade: &CoreFacade, id: String) -> Result<ItemsPage, String> {
+    facade
+        .set_current_vault(id)
+        .map_err(|err| err.to_string())?;
+    items(facade, None)
 }
 
 /// The servers and local vaults this machine knows about. One small read with

--- a/apps/cosmic/src/main.rs
+++ b/apps/cosmic/src/main.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 
 use cosmic::app::{Core, Settings, Task};
 use cosmic::iced::core::layout::Limits;
-use cosmic::iced::{event, keyboard, mouse, window, Event, Size, Subscription};
+use cosmic::iced::{event, keyboard, mouse, window, Event, Length, Size, Subscription};
 use cosmic::prelude::*;
 use cosmic::widget::{menu, nav_bar};
 use cosmic::{executor, widget, Application, Element};
@@ -304,6 +304,99 @@ impl cosmic::Application for App {
         }
     }
 
+    /// The default nav bar is the categories and nothing else. The desktop app
+    /// stacks three things in that column — which vault, the categories, the
+    /// folders — and the folders cannot join the categories in one model:
+    /// libcosmic's nav bar has a single selection, while a folder narrows
+    /// whatever category is showing rather than replacing it.
+    ///
+    /// So the categories keep the stock widget and the rest is drawn around it.
+    fn nav_bar(&self) -> Option<Element<'_, cosmic::Action<Message>>> {
+        if !self.core.nav_bar_active() {
+            return None;
+        }
+        let Shell::Ready {
+            screen: Screen::Vault(vault),
+            ..
+        } = &self.shell
+        else {
+            return None;
+        };
+        if self.settings_screen.is_some() {
+            return None;
+        }
+
+        let spacing = cosmic::theme::spacing();
+        let categories = widget::nav_bar(vault.nav_model(), |id| {
+            cosmic::Action::Cosmic(cosmic::app::Action::NavBar(id))
+        });
+
+        let mut column = widget::column::with_capacity(4).spacing(spacing.space_xs);
+        if let Some(vaults) = vault.vaults_view() {
+            column = column.push(vaults.map(|m| cosmic::Action::App(Message::Vault(m))));
+        }
+        column = column
+            .push(categories)
+            .push(widget::divider::horizontal::default())
+            .push(
+                widget::scrollable(vault.folders_view())
+                    .height(Length::Fill)
+                    .apply(Element::from)
+                    .map(|m| cosmic::Action::App(Message::Vault(m))),
+            );
+
+        // The stock nav bar paints its own background through `into_container`,
+        // which is bypassed by building the widget into a column, so the same
+        // style is put back here or the sidebar comes out transparent.
+        Some(
+            column
+                .apply(widget::container)
+                .class(cosmic::theme::Container::custom(
+                    cosmic::widget::nav_bar::nav_bar_style,
+                ))
+                .width(Length::Fixed(NAV_WIDTH - 8.0))
+                .height(Length::Fill)
+                .padding(spacing.space_xxs)
+                .into(),
+        )
+    }
+
+    fn on_nav_select(&mut self, id: nav_bar::Id) -> Task<Self::Message> {
+        let Shell::Ready {
+            screen: Screen::Vault(vault),
+            ..
+        } = &mut self.shell
+        else {
+            return Task::none();
+        };
+        vault.activate_nav(id);
+
+        let category = vault.selected_category();
+        if self
+            .settings
+            .remember(zann_cosmic::settings::Place::Category(category))
+        {
+            if let Err(err) = self.settings.save() {
+                eprintln!("could not save the settings: {err}");
+            }
+        }
+        Task::none()
+    }
+
+    /// The vault lays its two columns out itself, so it has to be told how much
+    /// of the window the nav bar left it.
+    fn on_window_resize(&mut self, _id: cosmic::iced::window::Id, width: f32, _height: f32) {
+        self.window_width = width;
+        let content_width = self.content_width();
+        if let Shell::Ready {
+            screen: Screen::Vault(vault),
+            ..
+        } = &mut self.shell
+        {
+            vault.set_content_width(content_width);
+        }
+    }
+
     fn subscription(&self) -> Subscription<Self::Message> {
         let screen = match &self.shell {
             Shell::Ready {
@@ -433,8 +526,14 @@ impl cosmic::Application for App {
         // The screens borrow `self.shell`, so losing the session is recorded
         // here and applied once that borrow ends.
         let mut lost_session = None;
+        let mut moved = None;
         let content_width = self.content_width();
         let reveal_seconds = self.settings.auto_hide_reveal_seconds;
+        let list_width = self.settings.list_width;
+        let last_category = self.settings.last_category.clone();
+        let last_category = last_category.as_deref();
+        let last_folder = self.settings.last_folder.clone();
+        let last_folder = last_folder.as_deref();
 
         let task = {
             let Shell::Ready { session, screen } = &mut self.shell else {
@@ -509,6 +608,11 @@ impl cosmic::Application for App {
                             let mut vault = vault::State::new(page, sync_error);
                             vault.set_content_width(content_width);
                             vault.set_reveal_seconds(reveal_seconds);
+                            vault.set_vaults(
+                                local::vaults(&session.facade()),
+                                local::current_vault(&session.facade()),
+                            );
+                            vault.restore(list_width, last_category, last_folder);
                             *screen = Screen::Vault(Box::new(vault));
                             Task::none()
                         }
@@ -523,6 +627,27 @@ impl cosmic::Application for App {
                         vault::Outcome::None => Task::none(),
                         vault::Outcome::Task(task) => lift(task, Message::Vault),
                         vault::Outcome::Copy(value) => cosmic::task::message(Message::Copy(value)),
+                        vault::Outcome::Moved(place) => {
+                            // Recorded here rather than saved: writing on every
+                            // pixel of a drag would hammer the file.
+                            moved = Some(place);
+                            Task::none()
+                        }
+                        vault::Outcome::SwitchVault(id) => {
+                            match local::switch_vault(&session.facade(), id) {
+                                Ok(page) => {
+                                    let vaults = local::vaults(&session.facade());
+                                    let current = local::current_vault(&session.facade());
+                                    let mut next = vault::State::new(page, None);
+                                    next.set_content_width(content_width);
+                                    next.set_reveal_seconds(reveal_seconds);
+                                    next.set_vaults(vaults, current);
+                                    *screen = Screen::Vault(Box::new(next));
+                                }
+                                Err(err) => eprintln!("could not switch the vault: {err}"),
+                            }
+                            Task::none()
+                        }
                     }
                 }
 
@@ -533,6 +658,13 @@ impl cosmic::Application for App {
 
         if let Some(err) = lost_session {
             self.shell = Shell::Blocked(err);
+        }
+        if let Some(place) = moved {
+            if self.settings.remember(place) {
+                if let Err(err) = self.settings.save() {
+                    eprintln!("could not save the settings: {err}");
+                }
+            }
         }
         task
     }

--- a/apps/cosmic/src/screens/vault.rs
+++ b/apps/cosmic/src/screens/vault.rs
@@ -5,15 +5,17 @@
 //! widths in [`layout`], so a reader moving between the clients is not asked to
 //! learn a second shape.
 
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use cosmic::iced::{event, mouse, Alignment, Event, Length, Subscription, Task};
 use cosmic::prelude::*;
 use cosmic::widget::nav_bar;
 use cosmic::{theme, widget, Element};
-use zann_ffi::ItemSummary;
+use zann_ffi::{ItemSummary, VaultSummaryFfi};
 use zann_ui_core::{
-    category_views, filtered_indices, FolderFilter, ItemCounts, ItemFilter, VaultScope,
+    build_folder_tree, category_views, filtered_indices, FolderFilter, FolderNode, FolderTree,
+    ItemCounts, ItemFilter, VaultScope,
 };
 
 use super::detail::{self, Detail};
@@ -21,6 +23,7 @@ use crate::backend::local::{self, ItemsPage};
 use crate::backend::off_thread;
 use crate::i18n::{t, t_args};
 use crate::session::Session;
+use crate::settings::Place;
 
 /// Schema icon names mapped onto the freedesktop names COSMIC ships.
 fn category_icon(schema_icon: &str) -> &'static str {
@@ -77,6 +80,17 @@ pub struct State {
     detail: Option<Detail>,
     busy: bool,
     error: Option<String>,
+    /// The sealed vaults on this storage, and which one is open. Handed down
+    /// by the shell, which is the one that can switch them.
+    vaults: Vec<VaultSummaryFfi>,
+    current_vault: Option<String>,
+    /// Rebuilt with the items; the sidebar draws it and the filter reads it.
+    folders: FolderTree,
+    /// Which folder narrows the list. Independent of the category, the way the
+    /// desktop app has them: picking a folder does not widen the type filter.
+    folder: FolderFilter,
+    /// Which folders are unfolded, by path. Everything starts closed.
+    expanded: BTreeSet<String>,
     /// How long a revealed field stays revealed, `0` for as long as it likes.
     reveal_seconds: u32,
     /// Bumped on every reveal, so a hide scheduled for an earlier one does not
@@ -104,6 +118,11 @@ pub enum Message {
     HideRevealed(u64),
     CloseDetail,
     Tick,
+    /// A folder row was picked. `None` is every folder, `Some("")` the items
+    /// that are in none.
+    SelectFolder(Option<String>),
+    ToggleFolder(String),
+    SwitchVault(String),
     ResizeStart,
     ResizeMove(f32),
     ResizeEnd,
@@ -114,6 +133,10 @@ pub enum Outcome {
     Task(Task<Message>),
     /// The clipboard belongs to the shell.
     Copy(String),
+    /// Where the reader now is, for the shell to write down.
+    Moved(Place),
+    /// Only the shell holds the session, so the switch is asked for.
+    SwitchVault(String),
 }
 
 impl State {
@@ -128,6 +151,11 @@ impl State {
             detail: None,
             busy: false,
             error: sync_error.map(|err| t_args("items.syncFailed", &[("error", &err)])),
+            vaults: Vec::new(),
+            current_vault: None,
+            folders: FolderTree::default(),
+            folder: FolderFilter::Any,
+            expanded: BTreeSet::new(),
             reveal_seconds: 0,
             reveal_generation: 0,
             list_width: layout::LIST_DEFAULT,
@@ -148,6 +176,44 @@ impl State {
     /// the nav bar left for these two columns.
     pub fn set_content_width(&mut self, width: f32) {
         self.content_width = width;
+    }
+
+    /// The shell owns the session, so switching vaults is its job; the screen
+    /// is only told what there is and which one it is looking at.
+    pub fn set_vaults(&mut self, vaults: Vec<VaultSummaryFfi>, current: Option<String>) {
+        self.vaults = vaults;
+        self.current_vault = current;
+    }
+
+    /// Restores where the reader left off. Called once, before the first draw.
+    pub fn restore(&mut self, list_width: f32, category: Option<&str>, folder: Option<&str>) {
+        self.list_width = list_width;
+        self.folder = match folder {
+            None => FolderFilter::Any,
+            Some("") => FolderFilter::WithoutFolder,
+            Some(path) => {
+                // Unfold down to it, or the selected row would be hidden.
+                let mut prefix = String::new();
+                for part in path.split('/') {
+                    if !prefix.is_empty() {
+                        prefix.push('/');
+                    }
+                    prefix.push_str(part);
+                    self.expanded.insert(prefix.clone());
+                }
+                FolderFilter::Path(path.to_string())
+            }
+        };
+        if let Some(category) = category {
+            let entity = self.nav.iter().find(|id| {
+                self.nav
+                    .data::<String>(*id)
+                    .is_some_and(|it| it == category)
+            });
+            if let Some(entity) = entity {
+                self.nav.activate(entity);
+            }
+        }
     }
 
     /// The shell owns the settings, so it is the one that says how long a
@@ -276,13 +342,7 @@ impl State {
                 if !revealed || self.reveal_seconds == 0 {
                     return Outcome::None;
                 }
-                self.reveal_generation += 1;
-                let generation = self.reveal_generation;
-                let seconds = u64::from(self.reveal_seconds);
-                return Outcome::Task(cosmic::task::future(async move {
-                    tokio::time::sleep(Duration::from_secs(seconds)).await;
-                    Message::HideRevealed(generation)
-                }));
+                return Outcome::Task(self.schedule_hide());
             }
 
             Message::HideRevealed(generation) => {
@@ -317,7 +377,27 @@ impl State {
                 self.list_width = self.clamped_list_width(desired);
             }
 
-            Message::ResizeEnd => self.drag = None,
+            Message::ResizeEnd => {
+                self.drag = None;
+                return Outcome::Moved(Place::ListWidth(self.list_width));
+            }
+
+            Message::SelectFolder(path) => {
+                self.folder = match path.as_deref() {
+                    None => FolderFilter::Any,
+                    Some("") => FolderFilter::WithoutFolder,
+                    Some(path) => FolderFilter::Path(path.to_string()),
+                };
+                return Outcome::Moved(Place::Folder(path));
+            }
+
+            Message::SwitchVault(id) => return Outcome::SwitchVault(id),
+
+            Message::ToggleFolder(path) => {
+                if !self.expanded.remove(&path) {
+                    self.expanded.insert(path);
+                }
+            }
         }
         Outcome::None
     }
@@ -328,6 +408,156 @@ impl State {
             .push(self.handle_view())
             .push(widget::container(self.detail_view()).width(Length::Fill))
             .height(Length::Fill)
+            .into()
+    }
+
+    /// Starts the clock that hides whatever was just revealed.
+    fn schedule_hide(&mut self) -> Task<Message> {
+        self.reveal_generation += 1;
+        let generation = self.reveal_generation;
+        let seconds = u64::from(self.reveal_seconds);
+        cosmic::task::future(async move {
+            tokio::time::sleep(Duration::from_secs(seconds)).await;
+            Message::HideRevealed(generation)
+        })
+    }
+
+    /// The vault picker that sits above the categories. Only drawn when there
+    /// is a choice to make.
+    pub fn vaults_view(&self) -> Option<Element<'_, Message>> {
+        if self.vaults.len() < 2 {
+            return None;
+        }
+        let names: Vec<String> = self.vaults.iter().map(|it| it.name.clone()).collect();
+        let selected = self
+            .current_vault
+            .as_deref()
+            .and_then(|current| self.vaults.iter().position(|it| it.id == current));
+        let ids: Vec<String> = self.vaults.iter().map(|it| it.id.clone()).collect();
+        Some(
+            widget::dropdown(names, selected, move |index| {
+                Message::SwitchVault(ids[index].clone())
+            })
+            .width(Length::Fill)
+            .into(),
+        )
+    }
+
+    /// The folder tree, under the categories in the sidebar. Its selection is
+    /// its own: a folder narrows whatever category is showing rather than
+    /// replacing it, which is why it cannot live in the nav bar's model.
+    pub fn folders_view(&self) -> Element<'_, Message> {
+        let spacing = theme::spacing();
+        let mut column =
+            widget::column::with_capacity(self.folders.tree.len() + 2).spacing(spacing.space_xxxs);
+
+        column = column.push(self.folder_row(
+            t("nav.folders"),
+            None,
+            self.total_folder_count(),
+            0,
+            None,
+        ));
+
+        for node in &self.folders.tree {
+            column = self.push_folder(column, node, 1);
+        }
+
+        if self.folders.items_without_folder > 0 {
+            column = column.push(self.folder_row(
+                t("nav.noFolder"),
+                Some(String::new()),
+                self.folders.items_without_folder,
+                1,
+                None,
+            ));
+        }
+
+        column.into()
+    }
+
+    fn total_folder_count(&self) -> usize {
+        self.folders
+            .tree
+            .iter()
+            .map(|node| node.total_count)
+            .sum::<usize>()
+            + self.folders.items_without_folder
+    }
+
+    fn push_folder<'a>(
+        &'a self,
+        mut column: widget::Column<'a, Message, cosmic::Theme>,
+        node: &'a FolderNode,
+        depth: u16,
+    ) -> widget::Column<'a, Message, cosmic::Theme> {
+        let expandable = (!node.children.is_empty()).then(|| node.path.clone());
+        column = column.push(self.folder_row(
+            node.name.clone(),
+            Some(node.path.clone()),
+            node.total_count,
+            depth,
+            expandable,
+        ));
+
+        if self.expanded.contains(&node.path) {
+            for child in &node.children {
+                column = self.push_folder(column, child, depth + 1);
+            }
+        }
+        column
+    }
+
+    /// One row: an optional twisty, the name, and how many items are under it.
+    fn folder_row(
+        &self,
+        label: String,
+        path: Option<String>,
+        count: usize,
+        depth: u16,
+        expandable: Option<String>,
+    ) -> Element<'_, Message> {
+        let spacing = theme::spacing();
+        let selected = match (&self.folder, path.as_deref()) {
+            (FolderFilter::Any, None) => true,
+            (FolderFilter::WithoutFolder, Some("")) => true,
+            (FolderFilter::Path(current), Some(path)) => current == path,
+            _ => false,
+        };
+
+        let twisty: Element<'_, Message> = match expandable {
+            Some(path) => {
+                widget::button::icon(widget::icon::from_name(if self.expanded.contains(&path) {
+                    "go-down-symbolic"
+                } else {
+                    "go-next-symbolic"
+                }))
+                .extra_small()
+                .on_press(Message::ToggleFolder(path))
+                .into()
+            }
+            // Keeps the names of childless folders in line with their siblings.
+            None => widget::Space::new().width(Length::Fixed(20.0)).into(),
+        };
+
+        let row = widget::row::with_capacity(3)
+            .push(twisty)
+            .push(widget::text::body(label).width(Length::Fill))
+            .push(widget::text::caption(count.to_string()))
+            .spacing(spacing.space_xxs)
+            .align_y(Alignment::Center);
+
+        widget::button::custom(row)
+            .class(if selected {
+                theme::Button::Suggested
+            } else {
+                theme::Button::Text
+            })
+            .width(Length::Fill)
+            .padding([spacing.space_xxxs, spacing.space_xxs])
+            .on_press(Message::SelectFolder(path))
+            .apply(widget::container)
+            .padding([0, 0, 0, depth * 12])
             .into()
     }
 
@@ -445,6 +675,7 @@ impl State {
         self.counts = page.counts;
         self.next_cursor = page.next_cursor;
         self.total = page.total;
+        self.folders = build_folder_tree(&self.items);
     }
 
     /// Rebuilds the nav entries from the shared schema, keeping the selection.
@@ -471,14 +702,14 @@ impl State {
         }
     }
 
-    fn selected_category(&self) -> Option<String> {
+    pub fn selected_category(&self) -> Option<String> {
         self.nav.active_data::<String>().cloned()
     }
 
     fn filter(&self) -> ItemFilter {
         ItemFilter {
             category_id: self.selected_category(),
-            folder: FolderFilter::Any,
+            folder: self.folder.clone(),
             query: self.query.clone(),
         }
     }

--- a/apps/cosmic/src/settings.rs
+++ b/apps/cosmic/src/settings.rs
@@ -19,7 +19,7 @@ use crate::backend::{client_root, default_db_url};
 
 const FILENAME: &str = "cosmic.json";
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {
     /// `None` is whatever the environment asks for, which is what an unset
@@ -39,6 +39,15 @@ pub struct Settings {
     pub clipboard_clear_if_unchanged: bool,
     /// Seconds a revealed field stays revealed. `0` is never.
     pub auto_hide_reveal_seconds: u32,
+
+    /// Where the reader left the app, so it opens where they left it. The
+    /// desktop app keeps the same three, and two more this one does not: the
+    /// search query and the selected item. Both say what someone went looking
+    /// for, and neither is worth writing to disk to save a click.
+    pub list_width: f32,
+    pub last_category: Option<String>,
+    /// `None` is every folder; `Some("")` is the items that are in none.
+    pub last_folder: Option<String>,
 }
 
 impl Default for Settings {
@@ -54,6 +63,9 @@ impl Default for Settings {
             clipboard_clear_on_exit: true,
             clipboard_clear_if_unchanged: true,
             auto_hide_reveal_seconds: 20,
+            list_width: 400.0,
+            last_category: None,
+            last_folder: None,
         }
     }
 }
@@ -72,6 +84,15 @@ pub enum Change {
     ClipboardOnExit(bool),
     ClipboardIfUnchanged(bool),
     AutoHideRevealSeconds(u32),
+}
+
+/// Where the reader was, reported by the vault when it moves. Separate from
+/// [`Change`] because nothing here is a preference the settings screen shows.
+#[derive(Clone, Debug)]
+pub enum Place {
+    ListWidth(f32),
+    Category(Option<String>),
+    Folder(Option<String>),
 }
 
 impl Settings {
@@ -105,6 +126,28 @@ impl Settings {
             Change::ClipboardOnExit(value) => self.clipboard_clear_on_exit = value,
             Change::ClipboardIfUnchanged(value) => self.clipboard_clear_if_unchanged = value,
             Change::AutoHideRevealSeconds(value) => self.auto_hide_reveal_seconds = value,
+        }
+    }
+
+    /// Returns whether anything moved, so an unchanged place does not rewrite
+    /// the file — dragging a splitter reports on every pixel.
+    pub fn remember(&mut self, place: Place) -> bool {
+        match place {
+            Place::ListWidth(value) => {
+                let changed = (self.list_width - value).abs() >= 1.0;
+                self.list_width = value;
+                changed
+            }
+            Place::Category(value) => {
+                let changed = self.last_category != value;
+                self.last_category = value;
+                changed
+            }
+            Place::Folder(value) => {
+                let changed = self.last_folder != value;
+                self.last_folder = value;
+                changed
+            }
         }
     }
 }

--- a/apps/cosmic/tests/flows.rs
+++ b/apps/cosmic/tests/flows.rs
@@ -354,6 +354,55 @@ fn settings_round_trip_through_a_file() {
 }
 
 #[test]
+fn a_folder_narrows_the_list_and_the_place_is_reported() {
+    let (_dir, session) = vault_with_items();
+    let page = local::items(&session.facade(), None).expect("items");
+    let mut state = vault::State::new(page, None);
+
+    // The fixture has `work/aws` and `personal/mail`.
+    assert_eq!(state.visible().len(), 2);
+
+    let outcome = state.update(
+        vault::Message::SelectFolder(Some("work".to_string())),
+        &session,
+    );
+    assert!(matches!(
+        outcome,
+        vault::Outcome::Moved(zann_cosmic::settings::Place::Folder(Some(ref path))) if path == "work"
+    ));
+    let visible = state.visible();
+    assert_eq!(visible.len(), 1);
+    assert_eq!(visible[0].path, "work/aws");
+
+    // A folder and the search compose, they do not replace each other.
+    state.update(vault::Message::QueryInput("mail".to_string()), &session);
+    assert!(state.visible().is_empty(), "mail does not live under work");
+
+    state.update(vault::Message::ClearQuery, &session);
+    state.update(vault::Message::SelectFolder(None), &session);
+    assert_eq!(state.visible().len(), 2);
+}
+
+#[test]
+fn the_last_place_comes_back_with_its_folder_unfolded() {
+    let (_dir, session) = vault_with_items();
+    let page = local::items(&session.facade(), None).expect("items");
+    let mut state = vault::State::new(page, None);
+
+    state.set_content_width(1200.0);
+    state.restore(520.0, None, Some("work"));
+    assert_eq!(state.list_width(), 520.0);
+
+    let visible = state.visible();
+    assert_eq!(visible.len(), 1);
+    assert_eq!(visible[0].path, "work/aws");
+
+    // A path with no folder behind it any more must not hide the whole list.
+    state.restore(520.0, None, None);
+    assert_eq!(state.visible().len(), 2);
+}
+
+#[test]
 fn connect_walks_the_stages_a_server_dictates() {
     let mut state = connect::State::default();
     assert_eq!(state.stage(), &connect::Stage::Server);


### PR DESCRIPTION
The desktop stacks three things in the sidebar: which vault, the categories, the folders. libcosmic's nav bar covers only the middle one, and the folders cannot join its model — a nav bar has one selection, while a folder narrows whatever category is showing rather than replacing it.

So `nav_bar` is overridden and the categories keep the stock widget inside it, with the vault picker above and the folder tree below. The tree comes from `zann_ui_core::build_folder_tree`, which the desktop already used.

`cosmic.json` also remembers the splitter width, the category and the folder. Two of the desktop's are deliberately not kept — the search query and the selected item both record what someone went looking for.

Verified: `cargo fmt`, `clippy`, `cargo test` (12, two new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)