### PR TITLE
fix(server): invalidate sessions when a device is revoked

### DIFF
--- a/crates/zann-db/src/repo/sessions.rs
+++ b/crates/zann-db/src/repo/sessions.rs
@@ -221,4 +221,26 @@ impl<'a> SessionRepo<'a> {
             Span::current().record("db.rows", result.rows_affected() as i64);
         })
     }
+
+    #[instrument(
+        level = "debug",
+        skip(self),
+        fields(db.system = "postgresql", db.operation = "DELETE", db.query = "sessions.delete_by_device")
+    )]
+    pub async fn delete_by_device(&self, device_id: Uuid) -> Result<u64, sqlx_core::Error> {
+        query!(
+            r#"
+            DELETE FROM sessions
+            WHERE device_id = $1
+            "#,
+            device_id
+        )
+        .execute(self.pool)
+        .await
+        .map(|result| {
+            let rows = result.rows_affected();
+            Span::current().record("db.rows", rows as i64);
+            rows
+        })
+    }
 }

--- a/crates/zann-server/src/domains/auth/core/identity.rs
+++ b/crates/zann-server/src/domains/auth/core/identity.rs
@@ -1,8 +1,8 @@
 use chrono::Utc;
 use zann_core::{extract_groups, AuthSource, Identity, OidcToken, User, UserStatus};
 use zann_db::repo::{
-    GroupMemberRepo, GroupRepo, OidcGroupMappingRepo, OidcIdentityRepo, ServiceAccountRepo,
-    ServiceAccountSessionRepo, SessionRepo, UserRepo,
+    DeviceRepo, GroupMemberRepo, GroupRepo, OidcGroupMappingRepo, OidcIdentityRepo,
+    ServiceAccountRepo, ServiceAccountSessionRepo, SessionRepo, UserRepo,
 };
 
 use crate::app::AppState;
@@ -300,6 +300,27 @@ pub async fn identity_from_service_account_token(
     .await
 }
 
+/// A revoked device must not be able to authenticate, however the caller got
+/// hold of a session row for it.
+pub(crate) async fn device_is_revoked(
+    state: &AppState,
+    device_id: uuid::Uuid,
+) -> Result<bool, &'static str> {
+    let device = DeviceRepo::new(&state.db)
+        .get_by_id(device_id)
+        .await
+        .map_err(|err| {
+            tracing::error!(
+                event = "auth_device_lookup_failed",
+                error = %err,
+                "Failed to load device"
+            );
+            "db_error"
+        })?;
+    // A session whose device row is gone is not trustworthy either.
+    Ok(device.is_none_or(|device| device.revoked_at.is_some()))
+}
+
 pub async fn identity_from_session_token(
     state: &AppState,
     token: &str,
@@ -322,6 +343,12 @@ pub async fn identity_from_session_token(
         })? {
         if session.access_expires_at < Utc::now() {
             return Err("token_expired");
+        }
+        // Deleting the device's sessions on revoke is the primary defence; this
+        // covers a session created concurrently with the revoke, and mirrors the
+        // service-account branch below, which already rejects on revoked_at.
+        if device_is_revoked(state, session.device_id).await? {
+            return Err("device_revoked");
         }
         (
             session.user_id,

--- a/crates/zann-server/src/domains/auth/service.rs
+++ b/crates/zann-server/src/domains/auth/service.rs
@@ -931,6 +931,24 @@ pub async fn refresh(
         return Err(AuthError::Unauthorized("token_expired"));
     }
 
+    // Refresh renews expires_at, so without this a stolen refresh token on a
+    // revoked device would keep the session alive indefinitely.
+    match crate::domains::auth::core::identity::device_is_revoked(state, session.device_id).await {
+        Ok(false) => {}
+        Ok(true) => {
+            tracing::info!(
+                event = "auth_refresh_device_revoked",
+                user_id = "redacted",
+                device_id = %session.device_id,
+                ip = %ctx.client_ip.as_deref().unwrap_or("unknown"),
+                request_id = %ctx.request_id.as_deref().unwrap_or("unknown"),
+                "Refresh rejected for revoked device"
+            );
+            return Err(AuthError::Unauthorized("device_revoked"));
+        }
+        Err(_) => return Err(AuthError::DbError),
+    }
+
     let new_refresh_token = Uuid::now_v7().to_string();
     let new_access_token = Uuid::now_v7().to_string();
     let new_refresh_hash = hash_token(&new_refresh_token, &state.token_pepper);

--- a/crates/zann-server/src/domains/devices/http/v1/mod.rs
+++ b/crates/zann-server/src/domains/devices/http/v1/mod.rs
@@ -10,7 +10,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use zann_core::{Device, Identity};
-use zann_db::repo::DeviceRepo;
+use zann_db::repo::{DeviceRepo, SessionRepo};
 
 use crate::app::AppState;
 use crate::infra::metrics;
@@ -180,9 +180,33 @@ async fn revoke_device(
         return StatusCode::NOT_FOUND.into_response();
     }
 
+    // Flagging the device is not enough on its own: its sessions stay valid and
+    // its refresh token keeps minting new ones. Drop them here, and let the
+    // revoked_at check in identity resolution cover anything raced in alongside.
+    let sessions_removed = match SessionRepo::new(&state.db)
+        .delete_by_device(device_id)
+        .await
+    {
+        Ok(count) => count,
+        Err(err) => {
+            tracing::error!(
+                event = "device_revoke_sessions_failed",
+                error = %err,
+                device_id = %device_id,
+                "Device flagged but its sessions could not be removed"
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse { error: "db_error" }),
+            )
+                .into_response();
+        }
+    };
+
     tracing::info!(
         event = "device_revoked",
         device_id = %device_id,
+        sessions_removed,
         "Device revoked"
     );
     StatusCode::NO_CONTENT.into_response()

--- a/crates/zann-server/tests/devices_groups_endpoints.rs
+++ b/crates/zann-server/tests/devices_groups_endpoints.rs
@@ -154,6 +154,14 @@ impl TestApp {
     }
 
     async fn login(&self, email: &str, password: &str) -> String {
+        self.login_full(email, password).await["access_token"]
+            .as_str()
+            .expect("token")
+            .to_string()
+    }
+
+    /// Full login response, for tests that also need the refresh token.
+    async fn login_full(&self, email: &str, password: &str) -> serde_json::Value {
         let payload = json!({
             "email": email,
             "password": password,
@@ -164,7 +172,7 @@ impl TestApp {
             .send_json(Method::POST, "/v1/auth/login", None, payload)
             .await;
         assert_eq!(status, StatusCode::OK, "login failed: {:?}", json);
-        json["access_token"].as_str().expect("token").to_string()
+        json
     }
 
     async fn add_admin_group(&self, user_id: Uuid) {
@@ -211,39 +219,106 @@ async fn devices_list_current_and_revoke() {
     let email = "device@example.com";
     let password = "password-1";
     app.register(email, password).await;
-    let token = app.login(email, password).await;
+    let revoked_token = app.login(email, password).await;
 
-    let (status, list) = app.get_json("/v1/devices", Some(&token)).await;
+    let (status, list) = app.get_json("/v1/devices", Some(&revoked_token)).await;
     assert_eq!(status, StatusCode::OK, "devices list failed: {:?}", list);
     let devices = list["devices"].as_array().expect("devices array");
     assert!(!devices.is_empty());
 
-    let (status, current) = app.get_json("/v1/devices/current", Some(&token)).await;
+    let (status, current) = app
+        .get_json("/v1/devices/current", Some(&revoked_token))
+        .await;
     assert_eq!(
         status,
         StatusCode::OK,
         "current device failed: {:?}",
         current
     );
-    let device_id = current["id"].as_str().expect("device id");
+    let device_id = current["id"].as_str().expect("device id").to_string();
+
+    // Every login registers a fresh device, so this second token is a different
+    // device — the realistic "revoke my other device from this one" flow. The
+    // revoking session has to be a different one now that revocation actually
+    // terminates the target device's sessions.
+    let surviving_token = app.login(email, password).await;
 
     let status = app
         .send_empty(
             Method::DELETE,
             &format!("/v1/devices/{}", device_id),
-            Some(&token),
+            Some(&surviving_token),
         )
         .await;
     assert_eq!(status, StatusCode::NO_CONTENT);
 
-    let (status, list) = app.get_json("/v1/devices", Some(&token)).await;
+    let (status, list) = app.get_json("/v1/devices", Some(&surviving_token)).await;
     assert_eq!(status, StatusCode::OK, "devices list failed: {:?}", list);
     let devices = list["devices"].as_array().expect("devices array");
     let revoked = devices
         .iter()
-        .find(|device| device["id"] == device_id)
+        .find(|device| device["id"].as_str() == Some(device_id.as_str()))
         .and_then(|device| device["revoked_at"].as_str());
     assert!(revoked.is_some());
+
+    // The revoked device loses access; the device that did the revoking keeps it.
+    let status = app
+        .send_empty(Method::GET, "/v1/devices", Some(&revoked_token))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "revoked device kept API access"
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "postgres-tests"), ignore = "requires TEST_DATABASE_URL")]
+async fn revoked_device_cannot_refresh() {
+    let app = TestApp::new().await;
+    let email = "device-refresh@example.com";
+    let password = "password-1";
+    app.register(email, password).await;
+
+    let session = app.login_full(email, password).await;
+    let access_token = session["access_token"].as_str().expect("access token");
+    let refresh_token = session["refresh_token"]
+        .as_str()
+        .expect("refresh token")
+        .to_string();
+
+    let (status, current) = app
+        .get_json("/v1/devices/current", Some(access_token))
+        .await;
+    assert_eq!(status, StatusCode::OK, "current device: {:?}", current);
+    let device_id = current["id"].as_str().expect("device id").to_string();
+
+    let admin_token = app.login(email, password).await;
+    let status = app
+        .send_empty(
+            Method::DELETE,
+            &format!("/v1/devices/{}", device_id),
+            Some(&admin_token),
+        )
+        .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    // Refresh renews expires_at, so if this succeeded the revoked device could
+    // keep the session alive forever.
+    let (status, body) = app
+        .send_json(
+            Method::POST,
+            "/v1/auth/refresh",
+            None,
+            json!({ "refresh_token": refresh_token }),
+        )
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "revoked device refreshed its session: {:?}",
+        body
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #133.

## Summary

Revoking a device set `devices.revoked_at` and nothing else. The device's rows in `sessions` survived, and no read path ever loaded the device: not `identity_from_session_token`, not `refresh`, not the sync prep that requires `identity.device_id`. So the revoked device's access token kept working, and its refresh token kept minting fresh access+refresh pairs with a renewed sliding `expires_at` — indefinitely. The service-account branch in the same file already rejects on `account.revoked_at`, which is what makes the device omission look like an oversight rather than a decision.

"Revoke device" is the only self-service remedy for a lost or stolen device, and it did nothing that an attacker holding the tokens would notice.

## Changes

- `SessionRepo::delete_by_device` (new) — `DELETE FROM sessions WHERE device_id = $1`.
- `revoke_device` calls it after flagging the device, and now fails with 500 rather than reporting success if the session cleanup errors. A device left flagged but live is exactly the state the bug was about.
- `device_is_revoked` helper in `identity.rs`, used by `identity_from_session_token` and by `refresh`. This is the belt to the braces: session deletion handles the normal case, the check covers a session created concurrently with the revoke. It also treats a missing device row as revoked.

## Testing

- [x] `cargo test` — 159 passed, 0 failed
- [x] `cargo test -p zann-server --features postgres-tests` — 163 passed, 0 failed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Both new assertions run against the unfixed code and confirmed to fail

`revoked_device_cannot_refresh` is new. `devices_list_current_and_revoke` had to be restructured: it revoked the current device and then asserted **200** on a request authenticated by that very device, so it pinned the vulnerable behaviour. It now revokes a second device from a first — every login registers a fresh device row, so that is the natural "revoke my other device" flow — and asserts the revoked device gets 401 while the revoking one keeps working.

## Risk / Notes

Auth path, so worth a careful read. Behaviour change users will notice: revoking the device you are currently on now logs that session out immediately, which is correct but is a change.

Deliberately left out of scope, surfaced by the same trace and worth separate tickets if you want them:

- `login` always INSERTs a new device row instead of matching on fingerprint, so a user accumulates a device per login and `revoked_at` was effectively write-only state. The fix makes revocation real, but the device list will still grow one row per login.
- `users::service::change_password` does not invalidate the user's other sessions.
- There is no delete-device endpoint and no admin session-kill.

Stacked on `claude/critical-issues-review-6297b0` (#132) because it touches `identity.rs` and `auth/service.rs`, which that PR also changes. Base it on `main` once #132 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
