### PR TITLE
feat(keystore): unlock with a FIDO2 hardware key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      # hidapi собирает C-часть для FIDO2-ключей (zann-keystore) и требует
+      # заголовки libudev; на ubuntu-latest их нет.
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
         with:
@@ -135,6 +141,12 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt-get clean
           df -h
+      # hidapi собирает C-часть для FIDO2-ключей (zann-keystore) и требует
+      # заголовки libudev; на ubuntu-latest их нет.
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
         with:
@@ -195,6 +207,12 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt-get clean
           df -h
+      # hidapi собирает C-часть для FIDO2-ключей (zann-keystore) и требует
+      # заголовки libudev; на ubuntu-latest их нет.
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
         with:
@@ -325,6 +343,7 @@ jobs:
             libayatana-appindicator3-dev \
             libxkbcommon-dev \
             libssl-dev \
+            libudev-dev \
             xvfb
           if ! sudo apt-get install -y webkit2gtk-driver; then
             sudo apt-get install -y webkit2gtk-4.1-driver

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -34,8 +34,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -147,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arboard"
@@ -234,6 +245,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -675,6 +725,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,7 +834,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -809,7 +877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -832,7 +900,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20 0.9.1",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -852,14 +920,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -993,6 +1098,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1199,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctap-hid-fido2"
+version = "3.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96157315d868b9012e2a7105d22badfbff69f191d2beb8d6f32487ad85c429e1"
+dependencies = [
+ "aes 0.9.2",
+ "anyhow",
+ "base64",
+ "byteorder",
+ "cbc 0.2.1",
+ "ciborium",
+ "hex",
+ "hidapi",
+ "num",
+ "pad",
+ "ring",
+ "strum",
+ "strum_macros",
+ "x509-parser",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1284,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,7 +1331,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -1880,6 +2036,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hidapi"
+version = "2.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78dadfc12f865bc3fcac3897e64533b930737ceb9ef245c8277de98d0b010e9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +2130,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2203,8 +2381,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2993,6 +3181,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,6 +3376,15 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "pad"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -3998,6 +4204,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4228,8 +4443,8 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5204d39df37f06d1944935232fd2dfe05008def7ca599bf28c0800366c8a8f9"
 dependencies = [
- "aes",
- "cbc",
+ "aes 0.8.4",
+ "cbc 0.1.2",
  "futures-util",
  "generic-array",
  "hkdf",
@@ -4842,6 +5057,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5439,6 +5672,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "uniffi"
 version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5560,7 +5799,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -6196,6 +6435,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6354,6 +6610,7 @@ dependencies = [
  "zann-core",
  "zann-crypto",
  "zann-db",
+ "zann-keystore",
  "zann-ui-core",
 ]
 
@@ -6363,9 +6620,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "blake3",
+ "ctap-hid-fido2",
  "keyring",
+ "rand 0.8.7",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
+ "zann-crypto",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6599,6 +6599,7 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "base64",
+ "chrono",
  "serde",
  "serde_json",
  "tempfile",

--- a/apps/cosmic/Cargo.lock
+++ b/apps/cosmic/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
  "accesskit_consumer",
  "atspi-common",
  "serde",
- "zvariant",
+ "zvariant 5.13.1",
 ]
 
 [[package]]
@@ -68,11 +68,11 @@ dependencies = [
  "accesskit",
  "accesskit_atspi_common",
  "atspi",
- "futures-lite",
+ "futures-lite 2.6.1",
  "serde",
  "tokio",
  "tokio-stream",
- "zbus",
+ "zbus 5.18.0",
 ]
 
 [[package]]
@@ -118,6 +118,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +150,15 @@ dependencies = [
  "once_cell",
  "version_check",
  "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -266,7 +297,7 @@ dependencies = [
  "serde_repr",
  "tokio",
  "url",
- "zbus",
+ "zbus 5.18.0",
 ]
 
 [[package]]
@@ -286,7 +317,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "zbus",
+ "zbus 5.18.0",
 ]
 
 [[package]]
@@ -331,12 +362,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+dependencies = [
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -362,10 +442,42 @@ checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand",
- "futures-lite",
+ "fastrand 2.5.0",
+ "futures-lite 2.6.1",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "blocking",
+ "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.28",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
 ]
 
 [[package]]
@@ -378,12 +490,21 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite",
+ "futures-lite 2.6.1",
  "parking",
- "polling",
+ "polling 3.11.0",
  "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -392,9 +513,26 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -404,14 +542,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
  "async-channel",
- "async-io",
- "async-lock",
+ "async-io 2.6.0",
+ "async-lock 3.4.2",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener",
- "futures-lite",
+ "event-listener 5.4.2",
+ "futures-lite 2.6.1",
  "rustix 1.1.4",
 ]
 
@@ -432,8 +570,8 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
- "async-io",
- "async-lock",
+ "async-io 2.6.0",
+ "async-lock 3.4.2",
  "atomic-waker",
  "cfg-if",
  "futures-core",
@@ -505,11 +643,11 @@ dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
- "zbus",
+ "zbus 5.18.0",
  "zbus-lockstep",
  "zbus-lockstep-macros",
- "zbus_names",
- "zvariant",
+ "zbus_names 4.3.4",
+ "zvariant 5.13.1",
 ]
 
 [[package]]
@@ -520,7 +658,7 @@ checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
 dependencies = [
  "atspi-common",
  "serde",
- "zbus",
+ "zbus 5.18.0",
 ]
 
 [[package]]
@@ -655,6 +793,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,7 +837,7 @@ dependencies = [
  "async-channel",
  "async-task",
  "futures-io",
- "futures-lite",
+ "futures-lite 2.6.1",
  "piper",
 ]
 
@@ -756,6 +912,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
  "bitflags 2.13.1",
- "polling",
+ "polling 3.11.0",
  "rustix 1.1.4",
  "slab",
  "tracing",
@@ -825,6 +987,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,7 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -878,7 +1058,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20 0.9.1",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -898,14 +1078,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -984,7 +1201,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1143,7 +1360,7 @@ dependencies = [
  "tokio",
  "tracing",
  "xdg",
- "zbus",
+ "zbus 5.18.0",
 ]
 
 [[package]]
@@ -1188,7 +1405,7 @@ name = "cosmic-settings-daemon"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
- "zbus",
+ "zbus 5.18.0",
 ]
 
 [[package]]
@@ -1232,6 +1449,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1344,6 +1567,28 @@ dependencies = [
  "phf",
  "serde",
  "uncased",
+]
+
+[[package]]
+name = "ctap-hid-fido2"
+version = "3.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96157315d868b9012e2a7105d22badfbff69f191d2beb8d6f32487ad85c429e1"
+dependencies = [
+ "aes 0.9.2",
+ "anyhow",
+ "base64",
+ "byteorder",
+ "cbc 0.2.1",
+ "ciborium",
+ "hex",
+ "hidapi",
+ "num",
+ "pad",
+ "ring",
+ "strum",
+ "strum_macros",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1474,6 +1719,37 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1796,6 +2072,23 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
@@ -1810,8 +2103,17 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.2",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -2126,11 +2428,26 @@ checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand",
+ "fastrand 2.5.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -2446,6 +2763,12 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -2472,6 +2795,28 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "hidapi"
+version = "2.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78dadfc12f865bc3fcac3897e64533b930737ceb9ef245c8277de98d0b010e9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -2600,7 +2945,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3119,7 +3464,27 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3139,6 +3504,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
 dependencies = [
  "unic-langid",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3324,6 +3700,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363387f0019d714aa60cc30ab4fe501a747f4c08fc58f069dd14be971bd495a0"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "linux-keyutils",
+ "secret-service",
+ "security-framework 2.11.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3391,6 +3781,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,7 +3838,7 @@ dependencies = [
  "tracing",
  "unicode-segmentation",
  "url",
- "zbus",
+ "zbus 5.18.0",
 ]
 
 [[package]]
@@ -3498,6 +3894,22 @@ name = "linebender_resource_handle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3643,6 +4055,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -3771,7 +4192,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3804,6 +4225,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
 ]
 
 [[package]]
@@ -3844,6 +4277,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3869,7 +4371,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4084,6 +4586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4217,6 +4728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pad"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
+dependencies = [
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4316,7 +4836,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "fastrand",
+ "fastrand 2.5.0",
  "phf_shared",
 ]
 
@@ -4389,7 +4909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
- "fastrand",
+ "fastrand 2.5.0",
  "futures-io",
 ]
 
@@ -4443,13 +4963,29 @@ dependencies = [
 
 [[package]]
 name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -4497,6 +5033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4513,11 +5055,21 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -4604,7 +5156,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -4642,7 +5194,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -4844,10 +5396,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "renderdoc-sys"
@@ -5040,6 +5615,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5217,6 +5815,38 @@ dependencies = [
  "memmap2 0.9.11",
  "smithay-client-toolkit",
  "tiny-skia 0.12.0",
+]
+
+[[package]]
+name = "secret-service"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5204d39df37f06d1944935232fd2dfe05008def7ca599bf28c0800366c8a8f9"
+dependencies = [
+ "aes 0.8.4",
+ "cbc 0.1.2",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.7",
+ "serde",
+ "sha2 0.10.9",
+ "zbus 3.15.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -5550,6 +6180,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -5569,7 +6209,7 @@ dependencies = [
  "cocoa",
  "core-graphics",
  "drm",
- "fastrand",
+ "fastrand 2.5.0",
  "foreign-types 0.5.0",
  "js-sys",
  "log",
@@ -5628,7 +6268,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener",
+ "event-listener 5.4.2",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -5740,6 +6380,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5770,6 +6428,17 @@ dependencies = [
  "skrifa 0.44.0",
  "yazi",
  "zeno",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -5862,7 +6531,7 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand",
+ "fastrand 2.5.0",
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
@@ -5925,6 +6594,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -6028,7 +6727,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6101,6 +6800,12 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
@@ -6110,14 +6815,25 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6126,7 +6842,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6261,7 +6977,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -6353,6 +7069,12 @@ name = "unicode-vo"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -6573,6 +7295,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -7725,6 +8453,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
@@ -7778,6 +8515,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "xcursor"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7788,6 +8542,16 @@ name = "xdg"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "xkbcommon"
@@ -7993,7 +8757,23 @@ dependencies = [
  "zann-core",
  "zann-crypto",
  "zann-db",
+ "zann-keystore",
  "zann-ui-core",
+]
+
+[[package]]
+name = "zann-keystore"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "blake3",
+ "ctap-hid-fido2",
+ "keyring",
+ "rand 0.8.7",
+ "serde",
+ "thiserror 1.0.69",
+ "zann-crypto",
 ]
 
 [[package]]
@@ -8009,23 +8789,64 @@ dependencies = [
 
 [[package]]
 name = "zbus"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
+dependencies = [
+ "async-broadcast 0.5.1",
+ "async-executor",
+ "async-fs",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-process 1.8.1",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "byteorder",
+ "derivative",
+ "enumflags2",
+ "event-listener 2.5.3",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "once_cell",
+ "ordered-stream",
+ "rand 0.8.7",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "winapi",
+ "xdg-home",
+ "zbus_macros 3.15.2",
+ "zbus_names 2.6.1",
+ "zvariant 3.15.2",
+]
+
+[[package]]
+name = "zbus"
 version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
 dependencies = [
- "async-broadcast",
+ "async-broadcast 0.7.2",
  "async-executor",
- "async-io",
- "async-lock",
- "async-process",
+ "async-io 2.6.0",
+ "async-lock 3.4.2",
+ "async-process 2.5.0",
  "async-recursion",
  "async-task",
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.2",
  "futures-core",
- "futures-lite",
+ "futures-lite 2.6.1",
  "hex",
  "libc",
  "ordered-stream",
@@ -8037,10 +8858,10 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "winnow 1.0.4",
+ "zbus_macros 5.18.0",
+ "zbus_names 4.3.4",
+ "zvariant 5.13.1",
 ]
 
 [[package]]
@@ -8050,7 +8871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
 dependencies = [
  "zbus_xml",
- "zvariant",
+ "zvariant 5.13.1",
 ]
 
 [[package]]
@@ -8064,7 +8885,21 @@ dependencies = [
  "syn 2.0.119",
  "zbus-lockstep",
  "zbus_xml",
- "zvariant",
+ "zvariant 5.13.1",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "zvariant_utils 1.0.1",
 ]
 
 [[package]]
@@ -8073,13 +8908,24 @@ version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.4",
+ "zvariant 5.13.1",
+ "zvariant_utils 3.5.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 3.15.2",
 ]
 
 [[package]]
@@ -8089,8 +8935,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow",
- "zvariant",
+ "winnow 1.0.4",
+ "zvariant 5.13.1",
 ]
 
 [[package]]
@@ -8100,9 +8946,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
 dependencies = [
  "serde",
- "winnow",
- "zbus_names",
- "zvariant",
+ "winnow 1.0.4",
+ "zbus_names 4.3.4",
+ "zvariant 5.13.1",
 ]
 
 [[package]]
@@ -8244,6 +9090,20 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 3.15.2",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
@@ -8252,9 +9112,22 @@ dependencies = [
  "enumflags2",
  "serde",
  "url",
- "winnow",
- "zvariant_derive",
- "zvariant_utils",
+ "winnow 1.0.4",
+ "zvariant_derive 5.13.1",
+ "zvariant_utils 3.5.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "zvariant_utils 1.0.1",
 ]
 
 [[package]]
@@ -8263,11 +9136,22 @@ version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "zvariant_utils",
+ "zvariant_utils 3.5.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8280,5 +9164,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.119",
- "winnow",
+ "winnow 1.0.4",
 ]

--- a/apps/cosmic/Cargo.lock
+++ b/apps/cosmic/Cargo.lock
@@ -8773,6 +8773,7 @@ dependencies = [
  "keyring",
  "rand 0.8.7",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "zann-crypto",
 ]

--- a/apps/cosmic/Cargo.lock
+++ b/apps/cosmic/Cargo.lock
@@ -8747,6 +8747,7 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "base64",
+ "chrono",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/apps/cosmic/src/backend/local.rs
+++ b/apps/cosmic/src/backend/local.rs
@@ -2,7 +2,10 @@
 
 use std::sync::Arc;
 
-use zann_ffi::{create_core, AppStatusFfi, CoreFacade, ItemDetail, ItemSummary, ItemsFilter, Page};
+use zann_ffi::{
+    create_core, AppStatusFfi, CoreFacade, HardwareKeyFfi, ItemDetail, ItemSummary, ItemsFilter,
+    Page, RememberedUnlockFfi,
+};
 use zann_ui_core::ItemCounts;
 
 use super::{default_db_url, local_root};
@@ -86,4 +89,40 @@ pub fn items(facade: &CoreFacade, cursor: Option<String>) -> Result<ItemsPage, S
 
 pub fn item_get(facade: &CoreFacade, id: String) -> Result<ItemDetail, String> {
     facade.item_get(id).map_err(|err| err.to_string())
+}
+
+// -- Remembered unlock -------------------------------------------------------
+//
+// The policy lives in `zann-keystore` behind `zann-ffi`; this app only asks.
+// Enrolment and unlocking wait on a physical touch, so both belong on a worker
+// thread like everything else here.
+
+pub fn remembered_unlock(facade: &CoreFacade) -> Result<RememberedUnlockFfi, String> {
+    facade.remembered_unlock().map_err(|err| err.to_string())
+}
+
+/// One touch when the source is a hardware key.
+pub fn unlock_remembered(facade: &CoreFacade) -> Result<(), String> {
+    facade
+        .unlock_remembered()
+        .map(|_| ())
+        .map_err(|err| err.to_string())
+}
+
+/// Silent — no touch. Safe to call while the user is doing something else.
+pub fn hardware_key_present(facade: &CoreFacade) -> Result<bool, String> {
+    facade.hardware_key_present().map_err(|err| err.to_string())
+}
+
+/// Two touches: create the credential, then prove it yields a secret.
+pub fn enroll_hardware_key(facade: &CoreFacade, label: String) -> Result<HardwareKeyFfi, String> {
+    facade
+        .enroll_hardware_key(label)
+        .map_err(|err| err.to_string())
+}
+
+pub fn remove_hardware_key(facade: &CoreFacade, credential_id: String) -> Result<(), String> {
+    facade
+        .remove_hardware_key(credential_id)
+        .map_err(|err| err.to_string())
 }

--- a/apps/cosmic/src/main.rs
+++ b/apps/cosmic/src/main.rs
@@ -17,7 +17,7 @@ use cosmic::iced::{Size, Subscription};
 use cosmic::prelude::*;
 use cosmic::widget::nav_bar;
 use cosmic::{executor, Element};
-use zann_cosmic::screens::{self, connect, master, vault, welcome, Screen};
+use zann_cosmic::screens::{self, connect, master, settings, vault, welcome, Screen};
 use zann_cosmic::session::Session;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -44,6 +44,7 @@ enum Message {
     Welcome(welcome::Message),
     Connect(connect::Message),
     Master(master::Message),
+    Settings(settings::Message),
     Vault(vault::Message),
     /// Effects the shell owns because they leave the app.
     Copy(String),
@@ -92,10 +93,36 @@ impl cosmic::Application for App {
 
         let mut app = App { core, shell };
         app.set_header_title("zann".to_string());
-        let task = match app.core.main_window_id() {
+        let mut task = match app.core.main_window_id() {
             Some(id) => app.set_window_title("zann".to_string(), id),
             None => Task::none(),
         };
+
+        if let Shell::Ready {
+            session,
+            screen: Screen::Master(_),
+        } = &app.shell
+        {
+            let facade = session.facade();
+            task = Task::batch([
+                task,
+                cosmic::task::future(async move {
+                    zann_cosmic::backend::off_thread(move || {
+                        zann_cosmic::backend::local::remembered_unlock(&facade)
+                    })
+                    .await
+                })
+                .map(|remembered: Result<_, String>| match remembered {
+                    Ok(remembered) => cosmic::Action::App(Message::Master(
+                        master::Message::Remembered(remembered),
+                    )),
+                    // Nothing remembered, or nothing readable: the password
+                    // path is always there, so this is not worth a banner.
+                    Err(_) => cosmic::Action::None,
+                }),
+            ]);
+        }
+
         (app, task)
     }
 
@@ -240,6 +267,25 @@ impl cosmic::Application for App {
                     }
                 }
 
+                Message::Settings(message) => {
+                    let Screen::Settings { state, .. } = &mut *screen else {
+                        return Task::none();
+                    };
+                    match state.update(message, session) {
+                        settings::Outcome::None => Task::none(),
+                        settings::Outcome::Task(task) => lift(task, Message::Settings),
+                        settings::Outcome::Close => {
+                            // Take the vault back out of the screen it was
+                            // parked in; `replace` keeps this a move.
+                            let parked = std::mem::replace(&mut *screen, Screen::Welcome);
+                            if let Screen::Settings { vault, .. } = parked {
+                                *screen = Screen::Vault(vault);
+                            }
+                            Task::none()
+                        }
+                    }
+                }
+
                 Message::Vault(message) => {
                     let Screen::Vault(state) = &mut *screen else {
                         return Task::none();
@@ -257,6 +303,18 @@ impl cosmic::Application for App {
                             *screen =
                                 Screen::Master(master::State::new(master::Mode::Unlock, None));
                             Task::none()
+                        }
+                        vault::Outcome::OpenSettings => {
+                            self.core.set_show_context(false);
+                            let load = settings::State::load(session);
+                            let parked = std::mem::replace(&mut *screen, Screen::Welcome);
+                            if let Screen::Vault(vault) = parked {
+                                *screen = Screen::Settings {
+                                    state: settings::State::new(),
+                                    vault,
+                                };
+                            }
+                            lift(load, Message::Settings)
                         }
                     }
                 }
@@ -280,6 +338,7 @@ impl cosmic::Application for App {
                 Screen::Connect(state) => state.view().map(Message::Connect),
                 Screen::Master(state) => state.view().map(Message::Master),
                 Screen::Vault(state) => state.view().map(Message::Vault),
+                Screen::Settings { state, .. } => state.view().map(Message::Settings),
             },
         }
     }

--- a/apps/cosmic/src/screens/master.rs
+++ b/apps/cosmic/src/screens/master.rs
@@ -7,6 +7,7 @@ use super::centered;
 use crate::backend::local::{self, ItemsPage};
 use crate::backend::off_thread;
 use crate::session::Session;
+use zann_ffi::RememberedUnlockFfi;
 
 /// Whether the screen creates a vault or opens one that already exists.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17,6 +18,9 @@ pub enum Mode {
 
 pub struct State {
     mode: Mode,
+    /// Whether this device can open the vault without the master password, and
+    /// with what. Absent until the shell has asked the facade.
+    remembered: Option<RememberedUnlockFfi>,
     password: String,
     hidden: bool,
     busy: bool,
@@ -27,6 +31,11 @@ pub struct State {
 
 #[derive(Clone, Debug)]
 pub enum Message {
+    /// What this device remembers, answered by the shell on the way in.
+    Remembered(RememberedUnlockFfi),
+    /// Unlock with the remembered source instead of the password. Waits on a
+    /// touch when that source is a hardware key.
+    UseRemembered,
     PasswordInput(String),
     ToggleVisibility,
     Submit,
@@ -47,6 +56,7 @@ impl State {
     pub fn new(mode: Mode, sync_after: Option<String>) -> Self {
         Self {
             mode,
+            remembered: None,
             password: String::new(),
             hidden: true,
             busy: false,
@@ -57,6 +67,17 @@ impl State {
 
     pub fn update(&mut self, message: Message, session: &Session) -> Outcome {
         match message {
+            Message::Remembered(remembered) => {
+                let armed = remembered.armed;
+                self.remembered = Some(remembered);
+                // A key already in the port should not need a click as well.
+                if armed && self.mode == Mode::Unlock && !self.busy {
+                    return self.unlock_remembered(session);
+                }
+            }
+
+            Message::UseRemembered => return self.unlock_remembered(session),
+
             Message::PasswordInput(value) => self.password = value,
 
             Message::ToggleVisibility => self.hidden = !self.hidden,
@@ -106,6 +127,31 @@ impl State {
         Outcome::None
     }
 
+    /// Open the vault with whatever this device remembers. Blocks the worker
+    /// thread on a touch when the source is a hardware key, which is why the
+    /// screen reports itself busy for the whole call.
+    fn unlock_remembered(&mut self, session: &Session) -> Outcome {
+        if self.busy {
+            return Outcome::None;
+        }
+        let facade = session.facade();
+        let storage = self.sync_after.take();
+        self.busy = true;
+        self.error = None;
+        Outcome::Task(cosmic::task::future(async move {
+            Message::Opened(
+                off_thread(move || {
+                    local::unlock_remembered(&facade)?;
+                    let sync_error = storage
+                        .map(|storage| local::sync(&facade, Some(storage)))
+                        .and_then(Result::err);
+                    local::items(&facade, None).map(|page| (page, sync_error))
+                })
+                .await,
+            )
+        }))
+    }
+
     pub fn view(&self) -> Element<'_, Message> {
         let spacing = theme::spacing();
         let (title, action) = match self.mode {
@@ -148,6 +194,19 @@ impl State {
 
         if let Some(error) = self.error.as_ref() {
             form = form.push(widget::text::caption(error.clone()));
+        }
+
+        if self.remembered.as_ref().is_some_and(|state| state.armed) && self.mode == Mode::Unlock {
+            let label = if self.busy {
+                "Touch your key…"
+            } else {
+                "Use the saved unlock"
+            };
+            let mut retry = widget::button::standard(label).width(Length::Fill);
+            if !self.busy {
+                retry = retry.on_press(Message::UseRemembered);
+            }
+            form = form.push(retry);
         }
 
         centered(form.push(submit))

--- a/apps/cosmic/src/screens/mod.rs
+++ b/apps/cosmic/src/screens/mod.rs
@@ -6,6 +6,7 @@
 pub mod connect;
 pub mod detail;
 pub mod master;
+pub mod settings;
 pub mod vault;
 pub mod welcome;
 
@@ -20,6 +21,12 @@ pub enum Screen {
     Connect(Box<connect::State>),
     Master(master::State),
     Vault(Box<vault::State>),
+    /// Reached from the vault and always returns to it, so the vault it came
+    /// from is parked here rather than rebuilt from the database.
+    Settings {
+        state: settings::State,
+        vault: Box<vault::State>,
+    },
 }
 
 /// The single-column layout the pre-vault screens share.

--- a/apps/cosmic/src/screens/settings.rs
+++ b/apps/cosmic/src/screens/settings.rs
@@ -1,0 +1,225 @@
+//! Security settings: how this device remembers the unlock.
+//!
+//! Only one source is ever active. Enrolling a key switches to it, and removing
+//! the last key switches back — that rule lives in `zann-keystore`, so this
+//! screen shows the result rather than deciding it.
+
+use cosmic::iced::{Alignment, Length, Task};
+use cosmic::{theme, widget, Element};
+use zann_ffi::RememberedUnlockFfi;
+
+use crate::backend::local;
+use crate::backend::off_thread;
+use crate::session::Session;
+
+pub struct State {
+    remembered: Option<RememberedUnlockFfi>,
+    /// Set while an authenticator is being waited on, so the view can say what
+    /// the user is supposed to do with it.
+    enrolling: bool,
+    busy: bool,
+    error: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Message {
+    Loaded(Result<RememberedUnlockFfi, String>),
+    Enroll,
+    Remove(String),
+    UseKeystore,
+    Forget,
+    Close,
+}
+
+pub enum Outcome {
+    None,
+    Task(Task<Message>),
+    Close,
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self {
+            remembered: None,
+            enrolling: false,
+            busy: false,
+            error: None,
+        }
+    }
+
+    /// Loading is a plain file read, but it goes through the same worker thread
+    /// as everything else so the facade is only touched from one place.
+    pub fn load(session: &Session) -> Task<Message> {
+        let facade = session.facade();
+        cosmic::task::future(async move {
+            Message::Loaded(off_thread(move || local::remembered_unlock(&facade)).await)
+        })
+    }
+
+    pub fn update(&mut self, message: Message, session: &Session) -> Outcome {
+        match message {
+            Message::Loaded(Ok(remembered)) => {
+                self.busy = false;
+                self.enrolling = false;
+                self.remembered = Some(remembered);
+            }
+
+            Message::Loaded(Err(err)) => {
+                self.busy = false;
+                self.enrolling = false;
+                self.error = Some(err);
+            }
+
+            Message::Enroll => {
+                if self.busy {
+                    return Outcome::None;
+                }
+                let facade = session.facade();
+                self.busy = true;
+                self.enrolling = true;
+                self.error = None;
+                return Outcome::Task(cosmic::task::future(async move {
+                    Message::Loaded(
+                        off_thread(move || {
+                            local::enroll_hardware_key(&facade, String::new())?;
+                            local::remembered_unlock(&facade)
+                        })
+                        .await,
+                    )
+                }));
+            }
+
+            Message::Remove(credential_id) => {
+                let facade = session.facade();
+                self.busy = true;
+                self.error = None;
+                return Outcome::Task(cosmic::task::future(async move {
+                    Message::Loaded(
+                        off_thread(move || {
+                            local::remove_hardware_key(&facade, credential_id)?;
+                            local::remembered_unlock(&facade)
+                        })
+                        .await,
+                    )
+                }));
+            }
+
+            Message::UseKeystore => {
+                let facade = session.facade();
+                self.busy = true;
+                self.error = None;
+                return Outcome::Task(cosmic::task::future(async move {
+                    Message::Loaded(
+                        off_thread(move || {
+                            facade
+                                .remember_with_keystore()
+                                .map_err(|err| err.to_string())?;
+                            local::remembered_unlock(&facade)
+                        })
+                        .await,
+                    )
+                }));
+            }
+
+            Message::Forget => {
+                let facade = session.facade();
+                self.busy = true;
+                self.error = None;
+                return Outcome::Task(cosmic::task::future(async move {
+                    Message::Loaded(
+                        off_thread(move || {
+                            facade.forget_remembered().map_err(|err| err.to_string())?;
+                            local::remembered_unlock(&facade)
+                        })
+                        .await,
+                    )
+                }));
+            }
+
+            Message::Close => return Outcome::Close,
+        }
+        Outcome::None
+    }
+
+    pub fn view(&self) -> Element<'_, Message> {
+        let spacing = theme::spacing();
+        let mut column = widget::column::with_capacity(8)
+            .push(widget::text::title3("Unlock on this device"))
+            .spacing(spacing.space_s)
+            .width(Length::Fixed(460.0));
+
+        let Some(remembered) = self.remembered.as_ref() else {
+            return super::centered(column.push(widget::text::body("Loading…")));
+        };
+
+        column = column.push(widget::text::body(match remembered.source.as_str() {
+            "hardware_key" => "Unlocking with a hardware key.",
+            _ if remembered.armed => "Unlocking with the system keystore.",
+            _ => "This device asks for the master password every time.",
+        }));
+
+        if remembered.hardware_supported {
+            for key in &remembered.hardware_keys {
+                column = column.push(
+                    widget::row::with_capacity(2)
+                        .push(
+                            widget::text::body(format!("{} · {}", key.label, key.enrolled_at))
+                                .width(Length::Fill),
+                        )
+                        .push(
+                            widget::button::text("Remove")
+                                .on_press(Message::Remove(key.credential_id.clone())),
+                        )
+                        .align_y(Alignment::Center),
+                );
+            }
+
+            let mut enroll = widget::button::standard(if self.enrolling {
+                "Insert the key and touch it…"
+            } else if remembered.hardware_keys.is_empty() {
+                "Enrol a hardware key"
+            } else {
+                "Enrol another key"
+            });
+            if !self.busy {
+                enroll = enroll.on_press(Message::Enroll);
+            }
+            column = column.push(enroll);
+
+            // Asked once, in the flow, because nobody goes looking for this.
+            if remembered.hardware_keys.len() == 1 {
+                column = column.push(widget::text::caption(
+                    "Add a backup key: if the only one is lost, unlocking falls back to the master password.",
+                ));
+            }
+        } else {
+            column = column.push(widget::text::caption(
+                "Hardware keys are not supported on this platform yet.",
+            ));
+        }
+
+        column = if remembered.armed {
+            column.push(
+                widget::button::text("Ask for the master password every time")
+                    .on_press(Message::Forget),
+            )
+        } else {
+            column.push(
+                widget::button::text("Remember with the system keystore")
+                    .on_press(Message::UseKeystore),
+            )
+        };
+
+        if let Some(error) = self.error.as_ref() {
+            column = column.push(widget::text::caption(error.clone()));
+        }
+
+        super::centered(column.push(widget::button::standard("Back").on_press(Message::Close)))
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/apps/cosmic/src/screens/vault.rs
+++ b/apps/cosmic/src/screens/vault.rs
@@ -1,6 +1,6 @@
 //! The open vault: nav categories, the item list, and the detail drawer.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use cosmic::app::context_drawer::{self, ContextDrawer};
 use cosmic::iced::{Alignment, Length, Subscription, Task};
@@ -61,6 +61,12 @@ fn item_icon(type_id: &str) -> &'static str {
     }
 }
 
+/// How long the vault stays open with nobody touching it.
+const AUTO_LOCK_AFTER: Duration = Duration::from_secs(10 * 60);
+/// How often that is checked. Coarse on purpose: the timeout is minutes, and
+/// each check can cost a query to the authenticator.
+const IDLE_TICK: Duration = Duration::from_secs(30);
+
 pub struct State {
     items: Vec<ItemSummary>,
     counts: ItemCounts,
@@ -71,6 +77,7 @@ pub struct State {
     detail: Option<Detail>,
     busy: bool,
     error: Option<String>,
+    last_activity: Instant,
 }
 
 #[derive(Clone, Debug)]
@@ -85,6 +92,10 @@ pub enum Message {
     CloseDetail,
     Lock,
     OpenSettings,
+    /// The idle timer expired; whether that locks depends on the answer below.
+    IdleCheck,
+    /// Whether an enrolled authenticator is still plugged in.
+    KeyPresent(bool),
     Tick,
 }
 
@@ -111,6 +122,7 @@ impl State {
             detail: None,
             busy: false,
             error: sync_error.map(|err| format!("sync failed: {err}")),
+            last_activity: Instant::now(),
         };
         state.apply_page(page, true);
         state.rebuild_nav();
@@ -151,15 +163,26 @@ impl State {
     /// One-time codes roll over every period, so an open drawer with one needs
     /// a redraw every second.
     pub fn subscription(&self) -> Subscription<Message> {
+        let idle = cosmic::iced::time::every(IDLE_TICK).map(|_| Message::IdleCheck);
         match self.detail.as_ref() {
-            Some(detail) if detail.has_totp() => {
-                cosmic::iced::time::every(Duration::from_secs(1)).map(|_| Message::Tick)
-            }
-            _ => Subscription::none(),
+            Some(detail) if detail.has_totp() => Subscription::batch([
+                cosmic::iced::time::every(Duration::from_secs(1)).map(|_| Message::Tick),
+                idle,
+            ]),
+            _ => idle,
         }
     }
 
     pub fn update(&mut self, message: Message, session: &Session) -> Outcome {
+        // Anything the user did counts as activity; the timer's own messages do
+        // not, or the vault would never idle out.
+        if !matches!(
+            message,
+            Message::IdleCheck | Message::KeyPresent(_) | Message::Tick
+        ) {
+            self.last_activity = Instant::now();
+        }
+
         match message {
             Message::QueryInput(value) => self.query = value,
 
@@ -228,6 +251,34 @@ impl State {
             }
 
             Message::OpenSettings => return Outcome::OpenSettings,
+
+            Message::IdleCheck => {
+                if self.last_activity.elapsed() < AUTO_LOCK_AFTER {
+                    return Outcome::None;
+                }
+                // An inserted key counts as presence: locking every ten minutes
+                // while it sits in the port only teaches people to turn the
+                // timeout off. Pulling the key is what locks.
+                let facade = session.facade();
+                return Outcome::Task(cosmic::task::future(async move {
+                    let present = off_thread(move || {
+                        let remembered = local::remembered_unlock(&facade)?;
+                        if remembered.source != "hardware_key" {
+                            return Ok(false);
+                        }
+                        local::hardware_key_present(&facade)
+                    })
+                    .await;
+                    Message::KeyPresent(present.unwrap_or(false))
+                }));
+            }
+
+            Message::KeyPresent(true) => self.last_activity = Instant::now(),
+
+            Message::KeyPresent(false) => {
+                session.lock();
+                return Outcome::Locked;
+            }
 
             Message::Tick => {}
         }

--- a/apps/cosmic/src/screens/vault.rs
+++ b/apps/cosmic/src/screens/vault.rs
@@ -84,6 +84,7 @@ pub enum Message {
     Detail(detail::Message),
     CloseDetail,
     Lock,
+    OpenSettings,
     Tick,
 }
 
@@ -95,6 +96,7 @@ pub enum Outcome {
     /// The drawer opened or closed; the shell owns that part of the window.
     ShowDetail(bool),
     Locked,
+    OpenSettings,
 }
 
 impl State {
@@ -225,6 +227,8 @@ impl State {
                 return Outcome::Locked;
             }
 
+            Message::OpenSettings => return Outcome::OpenSettings,
+
             Message::Tick => {}
         }
         Outcome::None
@@ -234,13 +238,14 @@ impl State {
         let spacing = theme::spacing();
         let visible = self.visible();
 
-        let toolbar = widget::row::with_capacity(2)
+        let toolbar = widget::row::with_capacity(3)
             .push(
                 widget::text_input::search_input("Search items", &self.query)
                     .on_input(Message::QueryInput)
                     .on_clear(Message::ClearQuery)
                     .width(Length::Fill),
             )
+            .push(widget::button::standard("Settings").on_press(Message::OpenSettings))
             .push(widget::button::standard("Lock").on_press(Message::Lock))
             .spacing(spacing.space_xs)
             .align_y(Alignment::Center);

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7795,6 +7795,7 @@ dependencies = [
  "keyring",
  "rand 0.8.7",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "zann-crypto",
 ]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -25,8 +25,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -70,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arboard"
@@ -90,7 +101,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -139,6 +150,45 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "zbus 5.12.0",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -514,6 +564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,7 +730,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -730,7 +798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -753,7 +821,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20 0.9.1",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -773,14 +841,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -907,6 +1012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1168,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctap-hid-fido2"
+version = "3.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96157315d868b9012e2a7105d22badfbff69f191d2beb8d6f32487ad85c429e1"
+dependencies = [
+ "aes 0.9.2",
+ "anyhow",
+ "base64 0.22.1",
+ "byteorder",
+ "cbc 0.2.1",
+ "ciborium",
+ "hex",
+ "hidapi",
+ "num",
+ "pad",
+ "ring",
+ "strum",
+ "strum_macros",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1155,6 +1297,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -1508,7 +1664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2258,6 +2414,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hidapi"
+version = "2.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78dadfc12f865bc3fcac3897e64533b930737ceb9ef245c8277de98d0b010e9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,6 +2504,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2611,8 +2789,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3002,6 +3190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,6 +3324,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nom"
@@ -3466,6 +3670,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,7 +3768,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pad"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -4128,7 +4350,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4509,6 +4731,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4545,7 +4776,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4683,8 +4914,8 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5204d39df37f06d1944935232fd2dfe05008def7ca599bf28c0800366c8a8f9"
 dependencies = [
- "aes",
- "cbc",
+ "aes 0.8.4",
+ "cbc 0.1.2",
  "futures-util",
  "generic-array",
  "hkdf",
@@ -5318,6 +5549,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5798,7 +6047,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6222,7 +6471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
 dependencies = [
  "memchr",
- "nom",
+ "nom 8.0.0",
  "petgraph",
 ]
 
@@ -6309,12 +6558,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -6771,7 +7026,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7388,6 +7643,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7518,9 +7790,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "blake3",
+ "ctap-hid-fido2",
  "keyring",
+ "rand 0.8.7",
  "serde",
  "thiserror 1.0.69",
+ "zann-crypto",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/src/commands/session.rs
+++ b/apps/desktop/src-tauri/src/commands/session.rs
@@ -4,7 +4,7 @@ use crate::services::session as session_service;
 use crate::state::AppState;
 use crate::types::{
     ApiResponse, AppStatusResponse, AutolockConfig, BootstrapResponse, DesktopSettings,
-    KeystoreStatusResponse, StatusResponse,
+    HardwareKeyEntry, KeystoreStatusResponse, StatusResponse,
 };
 
 #[tauri::command]
@@ -129,4 +129,39 @@ pub async fn unlock(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     session_service::unlock(app, password, state).await
+}
+
+#[tauri::command]
+pub async fn hardware_key_supported() -> Result<ApiResponse<bool>, String> {
+    session_service::hardware_key_supported().await
+}
+
+#[tauri::command]
+pub async fn hardware_key_present(state: State<'_, AppState>) -> Result<ApiResponse<bool>, String> {
+    session_service::hardware_key_present(state).await
+}
+
+#[tauri::command]
+pub async fn hardware_key_enroll(
+    state: State<'_, AppState>,
+    label: String,
+) -> Result<ApiResponse<HardwareKeyEntry>, String> {
+    session_service::hardware_key_enroll(state, label).await
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn hardware_key_remove(
+    state: State<'_, AppState>,
+    credentialId: String,
+) -> Result<ApiResponse<()>, String> {
+    session_service::hardware_key_remove(state, credentialId).await
+}
+
+#[tauri::command]
+pub async fn session_unlock_with_hardware_key(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<ApiResponse<()>, String> {
+    session_service::session_unlock_with_hardware_key(app, state).await
 }

--- a/apps/desktop/src-tauri/src/constants.rs
+++ b/apps/desktop/src-tauri/src/constants.rs
@@ -1,7 +1,6 @@
 pub const CONFIG_FILENAME: &str = "config.json";
 pub const LOCAL_DB_FILENAME: &str = "local.sqlite";
 pub const SETTINGS_FILENAME: &str = "desktop.json";
-pub const DWK_AAD: &[u8] = b"zann:dwk:wrap:v1";
 pub const SECURITY_PROFILES_YAML: &str = include_str!("../../../../schemas/security_profiles.yaml");
 pub const TOKEN_OIDC: &str = "oidc";
 pub const TOKEN_SESSION: &str = "session";

--- a/apps/desktop/src-tauri/src/infra/config.rs
+++ b/apps/desktop/src-tauri/src/infra/config.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use crate::constants::{CONFIG_FILENAME, SETTINGS_FILENAME};
 use crate::state::{CliConfig, CliContext};
 use crate::types::DesktopSettings;
+use zann_keystore::RememberedUnlock;
 
 pub fn load_config(root: &Path) -> Result<CliConfig, anyhow::Error> {
     let path = root.join(CONFIG_FILENAME);
@@ -24,19 +25,48 @@ pub fn save_config(root: &Path, config: &CliConfig) -> Result<(), anyhow::Error>
     Ok(())
 }
 
+/// UI preferences come from `desktop.json`; the remembered unlock comes from
+/// the file `zann-keystore` owns, so a key enrolled in another client is
+/// visible here too. Older `desktop.json` files carry it inline — those values
+/// are adopted once and then dropped on the next write.
 pub fn load_settings(root: &Path) -> Result<DesktopSettings, anyhow::Error> {
     let path = root.join(SETTINGS_FILENAME);
-    if !path.exists() {
-        return Ok(DesktopSettings::default());
+    let mut settings = if path.exists() {
+        serde_json::from_str::<DesktopSettings>(&std::fs::read_to_string(&path)?)?
+    } else {
+        DesktopSettings::default()
+    };
+
+    let shared = RememberedUnlock::load(root).map_err(|err| anyhow::anyhow!(err.to_string()))?;
+    if shared == RememberedUnlock::default() && settings.remembered != RememberedUnlock::default() {
+        settings
+            .remembered
+            .save(root)
+            .map_err(|err| anyhow::anyhow!(err.to_string()))?;
+    } else {
+        settings.remembered = shared;
     }
-    let contents = std::fs::read_to_string(path)?;
-    Ok(serde_json::from_str(&contents)?)
+    Ok(settings)
 }
 
 pub fn save_settings(root: &Path, settings: DesktopSettings) -> Result<(), anyhow::Error> {
-    let path = root.join(SETTINGS_FILENAME);
-    let contents = serde_json::to_string_pretty(&settings)?;
-    std::fs::write(path, contents)?;
+    settings
+        .remembered
+        .save(root)
+        .map_err(|err| anyhow::anyhow!(err.to_string()))?;
+
+    // The remembered fields are flattened into the API shape the UI reads, but
+    // they must not be written back into `desktop.json`: one owner per file.
+    let mut value = serde_json::to_value(&settings)?;
+    if let serde_json::Value::Object(map) = &mut value {
+        for key in ["unlock_source", "hardware_keys", "wrapped_master_key"] {
+            map.remove(key);
+        }
+    }
+    std::fs::write(
+        root.join(SETTINGS_FILENAME),
+        serde_json::to_string_pretty(&value)?,
+    )?;
     Ok(())
 }
 
@@ -54,4 +84,81 @@ pub fn ensure_context<'a>(config: &'a mut CliConfig, name: &str, addr: &str) -> 
             current_token: None,
             storage_id: None,
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zann_keystore::{HardwareKeyEntry, UnlockSource};
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("zann-cfg-{}-{}", name, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    fn enrolled() -> RememberedUnlock {
+        RememberedUnlock {
+            unlock_source: UnlockSource::HardwareKey,
+            hardware_keys: vec![HardwareKeyEntry {
+                label: "YubiKey".to_string(),
+                credential_id: "Y2lk".to_string(),
+                salt: "c2FsdA==".to_string(),
+                wrapped_master_key: "d3JhcHBlZA==".to_string(),
+                enrolled_at: "2026-08-08T00:00:00Z".to_string(),
+            }],
+            wrapped_master_key: None,
+        }
+    }
+
+    #[test]
+    fn an_inline_remembered_unlock_moves_to_the_shared_file() {
+        let root = scratch("migrate");
+        std::fs::write(
+            root.join(SETTINGS_FILENAME),
+            serde_json::to_string(&DesktopSettings {
+                remember_unlock: true,
+                remembered: enrolled(),
+                ..DesktopSettings::default()
+            })
+            .expect("serialize"),
+        )
+        .expect("write settings");
+
+        let loaded = load_settings(&root).expect("load");
+        assert_eq!(loaded.remembered, enrolled());
+        assert_eq!(RememberedUnlock::load(&root).expect("shared"), enrolled());
+    }
+
+    #[test]
+    fn the_shared_file_wins_over_a_stale_desktop_json() {
+        let root = scratch("shared-wins");
+        enrolled().save(&root).expect("save shared");
+        std::fs::write(root.join(SETTINGS_FILENAME), "{\"remember_unlock\":true}")
+            .expect("write settings");
+
+        assert_eq!(load_settings(&root).expect("load").remembered, enrolled());
+    }
+
+    #[test]
+    fn saving_leaves_the_remembered_unlock_out_of_desktop_json() {
+        let root = scratch("split");
+        save_settings(
+            &root,
+            DesktopSettings {
+                remember_unlock: true,
+                remembered: enrolled(),
+                ..DesktopSettings::default()
+            },
+        )
+        .expect("save");
+
+        let written = std::fs::read_to_string(root.join(SETTINGS_FILENAME)).expect("read");
+        assert!(!written.contains("hardware_keys"));
+        assert!(!written.contains("unlock_source"));
+        assert!(written.contains("remember_unlock"));
+        // ...and it is in the file the other clients read.
+        assert_eq!(RememberedUnlock::load(&root).expect("shared"), enrolled());
+    }
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -20,17 +20,18 @@ use commands::auth::{
     remote_trust_fingerprint,
 };
 use commands::backup::{backup_apple_import, backup_plain_export, backup_plain_import};
-use commands::totp::totp_generate;
 use commands::items::{
     items_delete, items_empty_trash, items_get, items_list, items_purge, items_purge_trash,
     items_put, items_resolve_conflict, items_restore, items_update, pending_changes_count,
 };
 use commands::items_history::{items_history_get, items_history_list, items_history_restore};
 use commands::session::{
-    app_status, bootstrap, get_settings, initialize_local_identity, initialize_master_password,
-    keystore_disable, keystore_enable, keystore_status, session_autolock_config, session_lock,
-    session_rebind_biometrics, session_status, session_unlock_with_biometrics,
-    session_unlock_with_password, status, system_locale, unlock, update_settings,
+    app_status, bootstrap, get_settings, hardware_key_enroll, hardware_key_present,
+    hardware_key_remove, hardware_key_supported, initialize_local_identity,
+    initialize_master_password, keystore_disable, keystore_enable, keystore_status,
+    session_autolock_config, session_lock, session_rebind_biometrics, session_status,
+    session_unlock_with_biometrics, session_unlock_with_hardware_key, session_unlock_with_password,
+    status, system_locale, unlock, update_settings,
 };
 use commands::shell::open_external_url;
 use commands::storage::{
@@ -39,6 +40,7 @@ use commands::storage::{
     storages_list,
 };
 use commands::sync::{remote_reset, remote_sync, sync_reset_cursor};
+use commands::totp::totp_generate;
 use commands::types::{publish_list, publish_trigger, types_list, types_show};
 use commands::vaults::{vault_create, vault_list, vault_reset_personal};
 use state::{build_state, AppState};
@@ -112,6 +114,11 @@ fn main() {
             keystore_status,
             keystore_enable,
             keystore_disable,
+            hardware_key_supported,
+            hardware_key_present,
+            hardware_key_enroll,
+            hardware_key_remove,
+            session_unlock_with_hardware_key,
             session_autolock_config,
             remote_begin_login,
             remote_trust_fingerprint,

--- a/apps/desktop/src-tauri/src/services/session.rs
+++ b/apps/desktop/src-tauri/src/services/session.rs
@@ -5,7 +5,6 @@ use rand::RngCore;
 use tauri::{Emitter, State};
 use tauri_plugin_biometry::{AuthOptions, BiometryExt};
 
-use crate::constants::DWK_AAD;
 use crate::crypto::decrypt_vault_key_with_master;
 use crate::infra::auth::ensure_access_token_for_context;
 use crate::infra::config::{load_config, load_settings, save_config, save_settings};
@@ -13,10 +12,11 @@ use crate::infra::http::{auth_headers, decode_json_response, ensure_success};
 use crate::state::AppState;
 use crate::types::{
     ApiResponse, AppStatusResponse, AutolockConfig, BootstrapResponse, DesktopSettings,
-    KeystoreStatusResponse, PersonalVaultStatusResponse, StatusResponse, VaultDetailResponse,
+    HardwareKeyEntry, KeystoreStatusResponse, PersonalVaultStatusResponse, StatusResponse,
+    UnlockSource, VaultDetailResponse,
 };
 use uuid::Uuid;
-use zann_core::crypto::{decrypt_blob, encrypt_blob, EncryptedBlob, SecretKey};
+use zann_core::crypto::SecretKey;
 use zann_core::VaultEncryptionType;
 use zann_core::{AppService, StorageKind, VaultKind};
 use zann_db::local::LocalVault;
@@ -389,9 +389,6 @@ pub async fn session_unlock_with_biometrics(
     state: State<'_, AppState>,
 ) -> Result<ApiResponse<()>, String> {
     let settings = state.settings.read().await.clone();
-    let Some(wrapped) = settings.wrapped_master_key.as_ref() else {
-        return Ok(ApiResponse::err("keystore_not_found", "No wrapped key"));
-    };
 
     if let Err((kind, message)) =
         confirm_with_os_auth(&app, "Unlock Zann", settings.require_os_auth)
@@ -399,52 +396,13 @@ pub async fn session_unlock_with_biometrics(
         return Ok(ApiResponse::err(&kind, &message));
     }
 
-    let dwk_bytes = match default_keystore().load_dwk() {
-        Ok(Some(bytes)) => bytes,
-        Ok(None) => return Ok(ApiResponse::err("keystore_not_found", "Not found")),
-        Err(err) => {
-            let (kind, message) = keystore_error(&err);
-            return Ok(ApiResponse::err(&kind, &message));
-        }
+    let master_key = match settings
+        .remembered
+        .unlock_with_keystore(default_keystore().as_ref())
+    {
+        Ok(key) => std::sync::Arc::new(SecretKey::from_bytes(key)),
+        Err(err) => return Ok(ApiResponse::err(err.kind(), &err.to_string())),
     };
-
-    let dwk_arr: [u8; 32] = match dwk_bytes.as_slice().try_into() {
-        Ok(arr) => arr,
-        Err(_) => {
-            return Ok(ApiResponse::err(
-                "keystore_unavailable",
-                "invalid dwk length",
-            ))
-        }
-    };
-    let dwk = SecretKey::from_bytes(dwk_arr);
-
-    let encoded = match base64::engine::general_purpose::STANDARD.decode(wrapped) {
-        Ok(bytes) => bytes,
-        Err(err) => return Ok(ApiResponse::err("keystore_unavailable", &err.to_string())),
-    };
-
-    let blob = match EncryptedBlob::from_bytes(&encoded) {
-        Ok(blob) => blob,
-        Err(err) => return Ok(ApiResponse::err("keystore_unavailable", &err.to_string())),
-    };
-
-    let master_bytes = match decrypt_blob(&dwk, &blob, DWK_AAD) {
-        Ok(bytes) => bytes,
-        Err(err) => return Ok(ApiResponse::err("keystore_unavailable", &err.to_string())),
-    };
-
-    let master_arr: [u8; 32] = match master_bytes.as_slice().try_into() {
-        Ok(arr) => arr,
-        Err(_) => {
-            return Ok(ApiResponse::err(
-                "keystore_unavailable",
-                "invalid master key length",
-            ))
-        }
-    };
-    let master_key = SecretKey::from_bytes(master_arr);
-    let master_key = std::sync::Arc::new(master_key);
 
     *state.master_key.write().await = Some(std::sync::Arc::clone(&master_key));
     handle_master_key_change(&app, &state, master_key.as_ref()).await?;
@@ -491,12 +449,10 @@ pub async fn session_rebind_biometrics(
             "remember unlock is disabled",
         ));
     }
-    let wrapped = match store_remembered_unlock(&app, master_key.as_ref(), settings.require_os_auth)
+    if let Err((kind, message)) = store_remembered_unlock(&app, &mut settings, master_key.as_ref())
     {
-        Ok(wrapped) => wrapped,
-        Err((kind, message)) => return Ok(ApiResponse::err(&kind, &message)),
-    };
-    settings.wrapped_master_key = Some(wrapped);
+        return Ok(ApiResponse::err(&kind, &message));
+    }
     if let Err(err) = save_settings(&state.root, settings.clone()) {
         return Ok(ApiResponse::err("keystore_error", &err.to_string()));
     }
@@ -509,24 +465,22 @@ pub fn system_locale() -> Result<ApiResponse<String>, String> {
     Ok(ApiResponse::ok(locale))
 }
 
-/// Remember the master key on this device: the DWK goes to the OS keystore and
-/// only the key it wraps is returned for storage in the settings file.
+/// Remember the master key on this device. The OS prompt is this client's job;
+/// everything below it belongs to `zann-keystore`.
 fn store_remembered_unlock(
     app: &tauri::AppHandle,
+    settings: &mut DesktopSettings,
     master_key: &SecretKey,
-    require_os_auth: bool,
-) -> Result<String, (String, String)> {
-    confirm_with_os_auth(app, "Enable unlock on this device", require_os_auth)?;
-
-    let dwk = SecretKey::generate();
-    default_keystore()
-        .store_dwk(dwk.as_bytes())
-        .map_err(|err| keystore_error(&err))?;
-
-    let blob = encrypt_blob(&dwk, master_key.as_bytes(), DWK_AAD)
-        .map_err(|err| ("keystore_error".to_string(), err.to_string()))?;
-
-    Ok(base64::engine::general_purpose::STANDARD.encode(blob.to_bytes()))
+) -> Result<(), (String, String)> {
+    confirm_with_os_auth(
+        app,
+        "Enable unlock on this device",
+        settings.require_os_auth,
+    )?;
+    settings
+        .remembered
+        .remember_with_keystore(default_keystore().as_ref(), master_key.as_bytes())
+        .map_err(|err| (err.kind().to_string(), err.to_string()))
 }
 
 /// Move a pre-keystore DWK out of the settings file.
@@ -541,19 +495,13 @@ fn migrate_legacy_dwk(
 ) -> Option<String> {
     let legacy = settings.legacy_dwk.take()?;
 
-    let stored = base64::engine::general_purpose::STANDARD
-        .decode(&legacy)
-        .map_err(|err| err.to_string())
-        .and_then(|bytes| keystore.store_dwk(&bytes).map_err(|err| err.to_string()));
-
-    let error = match stored {
+    let error = match settings.remembered.adopt_legacy_dwk(keystore, &legacy) {
         Ok(()) => None,
-        Err(message) => {
-            settings.wrapped_master_key = None;
+        Err(err) => {
             settings.remember_unlock = false;
             settings.auto_unlock = false;
             Some(format!(
-                "remembered unlock was reset because the system keystore is unavailable ({message})"
+                "remembered unlock was reset because the system keystore is unavailable ({err})"
             ))
         }
     };
@@ -588,26 +536,40 @@ pub async fn update_settings(
     let previous = state.settings.read().await.clone();
     let mut next = settings.clone();
     next.legacy_dwk = None;
+    // Enrolled keys are owned by the enrol/remove commands; a settings round
+    // trip through the UI must not be able to drop or rewrite them.
+    next.remembered.hardware_keys = previous.remembered.hardware_keys.clone();
 
-    if !previous.remember_unlock && settings.remember_unlock {
+    if next.remembered.unlock_source == UnlockSource::HardwareKey
+        && next.remembered.hardware_keys.is_empty()
+    {
+        return Err("enrol a hardware key first".to_string());
+    }
+
+    let keystore_active = |settings: &DesktopSettings| {
+        settings.remember_unlock && settings.remembered.unlock_source == UnlockSource::Keystore
+    };
+
+    if !keystore_active(&previous) && keystore_active(&next) {
         let master_key = state
             .master_key
             .read()
             .await
             .clone()
             .ok_or_else(|| "vault is locked".to_string())?;
-        let wrapped = store_remembered_unlock(&app, master_key.as_ref(), next.require_os_auth)
+        store_remembered_unlock(&app, &mut next, master_key.as_ref())
             .map_err(|(kind, message)| format!("{kind}: {message}"))?;
-        next.wrapped_master_key = Some(wrapped);
     }
 
-    if previous.remember_unlock && !settings.remember_unlock {
-        if let Err(err) = default_keystore().delete_dwk() {
-            if !matches!(err, KeystoreError::NotFound | KeystoreError::Unsupported) {
-                return Err(err.to_string());
-            }
-        }
-        next.wrapped_master_key = None;
+    if keystore_active(&previous) && !keystore_active(&next) {
+        // Includes switching to a hardware key: leaving the DWK behind would
+        // keep a second, weaker door into the same master key.
+        next.remembered
+            .forget_keystore(default_keystore().as_ref())
+            .map_err(|err| err.to_string())?;
+    }
+
+    if !next.remember_unlock {
         next.auto_unlock = false;
     }
 
@@ -635,10 +597,14 @@ pub async fn unlock(
     *state.master_key.write().await = Some(std::sync::Arc::clone(&master_key));
     handle_master_key_change(&app, &state, master_key.as_ref()).await?;
     let mut settings = state.settings.read().await.clone();
-    if settings.remember_unlock && settings.wrapped_master_key.is_none() {
-        match store_remembered_unlock(&app, master_key.as_ref(), settings.require_os_auth) {
-            Ok(wrapped) => {
-                settings.wrapped_master_key = Some(wrapped);
+    // Only the keystore source is (re)armed on a password unlock; a hardware
+    // key has to be enrolled deliberately, with the token in hand.
+    if settings.remember_unlock
+        && settings.remembered.unlock_source == UnlockSource::Keystore
+        && settings.remembered.wrapped_master_key.is_none()
+    {
+        match store_remembered_unlock(&app, &mut settings, master_key.as_ref()) {
+            Ok(()) => {
                 save_settings(&state.root, settings.clone()).map_err(|err| err.to_string())?;
                 *state.settings.write().await = settings;
             }
@@ -704,7 +670,7 @@ fn log_master_key_context(_label: &str, _password: &str, _identity: &crate::stat
 mod tests {
     use super::*;
     use std::sync::Mutex;
-    use zann_keystore::{KeystoreStatus, KeystoreStatusReason};
+    use zann_keystore::{KeystoreStatus, KeystoreStatusReason, RememberedUnlock};
 
     struct FakeKeystore {
         stored: Mutex<Option<Vec<u8>>>,
@@ -772,7 +738,10 @@ mod tests {
     fn remembered_settings(dwk: &str) -> DesktopSettings {
         DesktopSettings {
             remember_unlock: true,
-            wrapped_master_key: Some("wrapped".to_string()),
+            remembered: RememberedUnlock {
+                wrapped_master_key: Some("wrapped".to_string()),
+                ..RememberedUnlock::default()
+            },
             legacy_dwk: Some(dwk.to_string()),
             ..DesktopSettings::default()
         }
@@ -791,7 +760,10 @@ mod tests {
         assert_eq!(keystore.load_dwk().unwrap(), Some([3u8; 32].to_vec()));
         // The remembered unlock survives, only its key moved.
         assert!(settings.remember_unlock);
-        assert_eq!(settings.wrapped_master_key.as_deref(), Some("wrapped"));
+        assert_eq!(
+            settings.remembered.wrapped_master_key.as_deref(),
+            Some("wrapped")
+        );
         assert!(settings.legacy_dwk.is_none());
 
         let written =
@@ -812,7 +784,7 @@ mod tests {
         assert!(error.is_some());
         assert!(!settings.remember_unlock);
         assert!(!settings.auto_unlock);
-        assert!(settings.wrapped_master_key.is_none());
+        assert!(settings.remembered.wrapped_master_key.is_none());
         assert!(settings.legacy_dwk.is_none());
 
         let written =
@@ -825,7 +797,10 @@ mod tests {
         let root = scratch_dir("noop");
         let mut settings = DesktopSettings {
             remember_unlock: true,
-            wrapped_master_key: Some("wrapped".to_string()),
+            remembered: RememberedUnlock {
+                wrapped_master_key: Some("wrapped".to_string()),
+                ..RememberedUnlock::default()
+            },
             ..DesktopSettings::default()
         };
 
@@ -834,5 +809,127 @@ mod tests {
         assert!(error.is_none());
         assert!(settings.remember_unlock);
         assert!(!root.join(crate::constants::SETTINGS_FILENAME).exists());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hardware keys
+//
+// The enrolment, derivation and presence logic lives in `zann-keystore` so the
+// COSMIC client can reach the same behaviour. What stays here is the Tauri
+// plumbing: state, settings persistence, and the response shape.
+// ---------------------------------------------------------------------------
+
+/// Whether hardware keys can be used on this platform at all.
+pub async fn hardware_key_supported() -> Result<ApiResponse<bool>, String> {
+    Ok(ApiResponse::ok(cfg!(any(
+        target_os = "linux",
+        target_os = "macos"
+    ))))
+}
+
+/// Whether an enrolled authenticator is connected. Drives auto-lock, so it must
+/// stay silent: no touch, no prompt.
+pub async fn hardware_key_present(state: State<'_, AppState>) -> Result<ApiResponse<bool>, String> {
+    let settings = state.settings.read().await.clone();
+    Ok(ApiResponse::ok(
+        settings.remembered.connected_hardware_key().is_some(),
+    ))
+}
+
+pub async fn hardware_key_enroll(
+    state: State<'_, AppState>,
+    label: String,
+) -> Result<ApiResponse<HardwareKeyEntry>, String> {
+    let Some(master_key) = state.master_key.read().await.clone() else {
+        return Ok(ApiResponse::err("unlock_required", "unlock required"));
+    };
+
+    let mut settings = state.settings.read().await.clone();
+    let entry = match settings.remembered.enroll_hardware_key(
+        master_key.as_bytes(),
+        &label,
+        chrono::Utc::now().to_rfc3339(),
+    ) {
+        Ok(entry) => entry,
+        Err(err) => return Ok(ApiResponse::err(err.kind(), &err.to_string())),
+    };
+
+    save_settings(&state.root, settings.clone()).map_err(|err| err.to_string())?;
+    *state.settings.write().await = settings;
+    Ok(ApiResponse::ok(entry))
+}
+
+pub async fn hardware_key_remove(
+    state: State<'_, AppState>,
+    credential_id: String,
+) -> Result<ApiResponse<()>, String> {
+    let mut settings = state.settings.read().await.clone();
+    settings.remembered.remove_hardware_key(&credential_id);
+
+    // Removing the last key would leave the unlock screen waiting for a token
+    // that can never answer.
+    if !settings.remembered.is_armed() {
+        settings.remember_unlock = false;
+        settings.auto_unlock = false;
+    }
+
+    save_settings(&state.root, settings.clone()).map_err(|err| err.to_string())?;
+    *state.settings.write().await = settings;
+    Ok(ApiResponse::ok(()))
+}
+
+pub async fn session_unlock_with_hardware_key(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<ApiResponse<()>, String> {
+    let settings = state.settings.read().await.clone();
+    let master_key = match settings.remembered.unlock_with_hardware_key() {
+        Ok(key) => std::sync::Arc::new(SecretKey::from_bytes(key)),
+        Err(err) => return Ok(ApiResponse::err(err.kind(), &err.to_string())),
+    };
+
+    *state.master_key.write().await = Some(std::sync::Arc::clone(&master_key));
+    handle_master_key_change(&app, &state, master_key.as_ref()).await?;
+    Ok(ApiResponse::ok(()))
+}
+
+#[cfg(test)]
+mod settings_format_tests {
+    use super::*;
+
+    /// The remembered-unlock fields moved into a shared struct; they must still
+    /// sit at the top level of `desktop.json`, or every existing install loses
+    /// its remembered unlock on upgrade.
+    #[test]
+    fn settings_files_written_before_the_move_still_parse() {
+        let json = r#"{
+            "remember_unlock": true,
+            "unlock_source": "hardware_key",
+            "wrapped_master_key": "d3JhcHBlZA==",
+            "hardware_keys": [{
+                "label": "YubiKey",
+                "credential_id": "Y2lk",
+                "salt": "c2FsdA==",
+                "wrapped_master_key": "d3JhcHBlZA==",
+                "enrolled_at": "2026-08-08T00:00:00Z"
+            }]
+        }"#;
+
+        let settings: DesktopSettings = serde_json::from_str(json).expect("parse");
+        assert!(settings.remember_unlock);
+        assert_eq!(settings.remembered.unlock_source, UnlockSource::HardwareKey);
+        assert_eq!(settings.remembered.hardware_keys.len(), 1);
+        assert_eq!(settings.remembered.hardware_keys[0].label, "YubiKey");
+        assert_eq!(
+            settings.remembered.wrapped_master_key.as_deref(),
+            Some("d3JhcHBlZA==")
+        );
+
+        // And round-trips back to the same flat shape.
+        let written = serde_json::to_string(&settings).expect("serialize");
+        assert!(written.contains("\"unlock_source\":\"hardware_key\""));
+        assert!(written.contains("\"hardware_keys\":["));
+        assert!(!written.contains("\"remembered\""));
     }
 }

--- a/apps/desktop/src-tauri/src/services/session.rs
+++ b/apps/desktop/src-tauri/src/services/session.rs
@@ -898,9 +898,8 @@ pub async fn session_unlock_with_hardware_key(
 mod settings_format_tests {
     use super::*;
 
-    /// The remembered-unlock fields moved into a shared struct; they must still
-    /// sit at the top level of `desktop.json`, or every existing install loses
-    /// its remembered unlock on upgrade.
+    /// Older `desktop.json` files carry the remembered unlock inline. Parsing
+    /// has to keep working, or an upgrade silently loses every enrolment.
     #[test]
     fn settings_files_written_before_the_move_still_parse() {
         let json = r#"{
@@ -926,7 +925,7 @@ mod settings_format_tests {
             Some("d3JhcHBlZA==")
         );
 
-        // And round-trips back to the same flat shape.
+        // The API shape the UI reads stays flat, whatever the file looks like.
         let written = serde_json::to_string(&settings).expect("serialize");
         assert!(written.contains("\"unlock_source\":\"hardware_key\""));
         assert!(written.contains("\"hardware_keys\":["));

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -365,13 +365,19 @@ pub struct KeystoreStatusResponse {
     pub reason: Option<String>,
 }
 
+pub use zann_keystore::{HardwareKeyEntry, RememberedUnlock, UnlockSource};
+
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct DesktopSettings {
     pub remember_unlock: bool,
     pub auto_unlock: bool,
     pub language: Option<String>,
-    pub wrapped_master_key: Option<String>,
+    /// Which device key opens the remembered unlock, and the keys it opens.
+    /// Flattened so the on-disk field names stay what they were and match the
+    /// other clients.
+    #[serde(flatten)]
+    pub remembered: RememberedUnlock,
     /// Pre-keystore installs kept the device wrapping key here, next to the
     /// key it unwraps. Read once on bootstrap so it can be moved into the OS
     /// keystore, and never written back — see `migrate_legacy_dwk`.
@@ -397,7 +403,7 @@ impl Default for DesktopSettings {
             remember_unlock: false,
             auto_unlock: false,
             language: None,
-            wrapped_master_key: None,
+            remembered: RememberedUnlock::default(),
             legacy_dwk: None,
             auto_lock_minutes: 10,
             lock_on_focus_loss: false,

--- a/apps/desktop/src/__tests__/AppLastSyncTime.test.ts
+++ b/apps/desktop/src/__tests__/AppLastSyncTime.test.ts
@@ -393,6 +393,8 @@ describe("App last sync time", () => {
             auto_hide_reveal_seconds: 20,
             require_os_auth: true,
             wrapped_master_key: null,
+            unlock_source: "keystore",
+            hardware_keys: [],
             trash_auto_purge_days: 90,
             close_to_tray: true,
             close_to_tray_notice_shown: false,

--- a/apps/desktop/src/components/UnlockModal.vue
+++ b/apps/desktop/src/components/UnlockModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 import type { KeystoreStatus, Settings } from "../types";
+import { useHardwareKeys } from "../composables/useHardwareKeys";
 import Button from "./ui/Button.vue";
 
 type Translator = (key: string) => string;
@@ -27,14 +28,37 @@ const props = withDefaults(defineProps<{
 
 const passwordInput = ref<HTMLInputElement | null>(null);
 const biometricsAttempted = ref(false);
+const hardwareKeys = useHardwareKeys();
+const hardwareAttempted = ref(false);
+
+const usingHardwareKey = computed(
+  () =>
+    props.allowBiometrics !== false &&
+    props.settings?.remember_unlock === true &&
+    props.settings?.unlock_source === "hardware_key" &&
+    (props.settings?.hardware_keys?.length ?? 0) > 0,
+);
 
 const canUseBiometrics = computed(() => {
   if (props.allowBiometrics === false) return false;
+  if (usingHardwareKey.value) return false;
   if (!props.settings?.remember_unlock) return false;
   if (!props.settings?.wrapped_master_key) return false;
   if (!props.keystoreStatus) return true;
   return props.keystoreStatus.supported;
 });
+
+/**
+ * Ask for the touch as soon as the screen opens rather than behind a button:
+ * the key is already in the port, so a click is pure friction. Runs once per
+ * opening, because a second assertion while the first is pending would just
+ * fight over the device.
+ */
+const unlockWithHardwareKey = async () => {
+  if (hardwareAttempted.value || hardwareKeys.busy.value) return;
+  hardwareAttempted.value = true;
+  await hardwareKeys.unlock();
+};
 
 const shouldAutoBiometrics = () =>
   canUseBiometrics.value &&
@@ -52,7 +76,11 @@ watch(
   ([isOpen]) => {
     if (!isOpen) {
       biometricsAttempted.value = false;
+      hardwareAttempted.value = false;
       return;
+    }
+    if (usingHardwareKey.value) {
+      void unlockWithHardwareKey();
     }
     void focusPassword();
   },
@@ -105,6 +133,23 @@ onMounted(() => {
       >
         {{ t("common.unlock") }}
       </Button>
+      <div v-if="usingHardwareKey" class="mt-4 space-y-2">
+        <p class="text-sm text-[var(--text-secondary)]">
+          {{ hardwareKeys.busy.value ? t("unlock.hardwareKeyTouch") : t("unlock.hardwareKeyPrompt") }}
+        </p>
+        <p v-if="hardwareKeys.error.value" class="text-xs text-category-security">
+          {{ t(`errors.${hardwareKeys.error.value}`) }}
+        </p>
+        <Button
+          v-if="hardwareKeys.error.value && !hardwareKeys.busy.value"
+          variant="outline"
+          size="sm"
+          full-width
+          @click="hardwareAttempted = false; unlockWithHardwareKey()"
+        >
+          {{ t("unlock.hardwareKeyRetry") }}
+        </Button>
+      </div>
       <Button
         v-if="canUseBiometrics"
         class="mt-4"

--- a/apps/desktop/src/components/__tests__/SettingsTabGeneral.test.ts
+++ b/apps/desktop/src/components/__tests__/SettingsTabGeneral.test.ts
@@ -17,6 +17,8 @@ const createSettings = (overrides: Partial<Settings> = {}): Settings => ({
   auto_hide_reveal_seconds: 20,
   require_os_auth: true,
   wrapped_master_key: null,
+  unlock_source: "keystore",
+  hardware_keys: [],
   trash_auto_purge_days: 90,
   close_to_tray: true,
   close_to_tray_notice_shown: false,

--- a/apps/desktop/src/components/settings/SettingsTabSecurity.vue
+++ b/apps/desktop/src/components/settings/SettingsTabSecurity.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
 import type { KeystoreStatus, Settings } from "../../types";
+import { useHardwareKeys } from "../../composables/useHardwareKeys";
 
 type Translator = (key: string) => string;
 
@@ -25,6 +26,45 @@ const autoUnlockDisabled = computed(
 const requireOsAuthDisabled = computed(
   () => !props.rememberEnabled || (!keystoreSupported.value && !props.settings?.require_os_auth),
 );
+
+const hardwareKeys = useHardwareKeys();
+const hardwareSupported = ref(false);
+const enrolling = ref(false);
+/** Shown once, right after the first key: nobody enrols a backup otherwise. */
+const offerBackupKey = ref(false);
+
+onMounted(async () => {
+  hardwareSupported.value = await hardwareKeys.supported();
+});
+
+const enrolledKeys = computed(() => props.settings?.hardware_keys ?? []);
+const usingHardwareKey = computed(() => props.settings?.unlock_source === "hardware_key");
+
+const enrollKey = async () => {
+  enrolling.value = true;
+  const wasEmpty = enrolledKeys.value.length === 0;
+  const entry = await hardwareKeys.enroll("");
+  enrolling.value = false;
+  if (!entry) {
+    return;
+  }
+  // The source only flips once there is something behind it.
+  props.updateSettings({ remember_unlock: true, unlock_source: "hardware_key" });
+  offerBackupKey.value = wasEmpty;
+};
+
+const removeKey = async (credentialId: string) => {
+  await hardwareKeys.remove(credentialId);
+  props.updateSettings({});
+};
+
+const handleSourceChange = (source: "keystore" | "hardware_key") => {
+  if (source === "hardware_key" && enrolledKeys.value.length === 0) {
+    void enrollKey();
+    return;
+  }
+  props.updateSettings({ unlock_source: source });
+};
 
 const handleRememberUnlockChange = (event: Event) => {
   const checked = (event.target as HTMLInputElement).checked;
@@ -177,6 +217,56 @@ const handleRememberUnlockChange = (event: Event) => {
           />
           <span>{{ t("unlock.remember") }}</span>
         </label>
+
+        <div v-if="hardwareSupported && rememberEnabled" class="ml-6 space-y-2">
+          <label class="flex items-center gap-2 text-[var(--text-secondary)]">
+            <input
+              type="radio"
+              :checked="!usingHardwareKey"
+              @change="handleSourceChange('keystore')"
+            />
+            <span>{{ t("settings.unlockSourceKeystore") }}</span>
+          </label>
+          <label class="flex items-center gap-2 text-[var(--text-secondary)]">
+            <input
+              type="radio"
+              :checked="usingHardwareKey"
+              @change="handleSourceChange('hardware_key')"
+            />
+            <span>{{ t("settings.unlockSourceHardwareKey") }}</span>
+          </label>
+
+          <div v-if="usingHardwareKey" class="ml-6 space-y-2">
+            <div
+              v-for="key in enrolledKeys"
+              :key="key.credential_id"
+              class="flex items-center justify-between gap-3 text-xs text-[var(--text-secondary)]"
+            >
+              <span>{{ key.label }}</span>
+              <button
+                type="button"
+                class="text-category-security hover:underline"
+                @click="removeKey(key.credential_id)"
+              >
+                {{ t("common.delete") }}
+              </button>
+            </div>
+            <button
+              type="button"
+              class="rounded-lg border border-[var(--border-color)] px-3 py-2 text-sm text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors disabled:opacity-60"
+              :disabled="enrolling"
+              @click="enrollKey"
+            >
+              {{ enrolling ? t("settings.hardwareKeyTouch") : t("settings.hardwareKeyEnrol") }}
+            </button>
+            <p v-if="offerBackupKey" class="text-xs text-[var(--text-tertiary)]">
+              {{ t("settings.hardwareKeyBackupHint") }}
+            </p>
+            <p v-if="hardwareKeys.error.value" class="text-xs text-category-security">
+              {{ t(`errors.${hardwareKeys.error.value}`) }}
+            </p>
+          </div>
+        </div>
         <label class="flex items-center gap-2 text-[var(--text-secondary)]">
           <input
             type="checkbox"
@@ -187,7 +277,12 @@ const handleRememberUnlockChange = (event: Event) => {
           />
           <span>{{ t("unlock.autoUnlock") }}</span>
         </label>
-        <label class="flex items-center gap-2 text-[var(--text-secondary)]">
+        <!-- A touch already proves presence; a biometric prompt on top is
+             ceremony, so the toggle is hidden while a key is the source. -->
+        <label
+          v-if="!usingHardwareKey"
+          class="flex items-center gap-2 text-[var(--text-secondary)]"
+        >
           <input
             type="checkbox"
             class="rounded disabled:opacity-60 disabled:cursor-not-allowed"

--- a/apps/desktop/src/composables/app/actions/__tests__/useAppEventHandlers.test.ts
+++ b/apps/desktop/src/composables/app/actions/__tests__/useAppEventHandlers.test.ts
@@ -29,6 +29,8 @@ const createSettings = (): Settings => ({
   auto_hide_reveal_seconds: 20,
   require_os_auth: true,
   wrapped_master_key: null,
+  unlock_source: "keystore",
+  hardware_keys: [],
   trash_auto_purge_days: 90,
   close_to_tray: true,
   close_to_tray_notice_shown: false,

--- a/apps/desktop/src/composables/app/actions/useAppWatchers.ts
+++ b/apps/desktop/src/composables/app/actions/useAppWatchers.ts
@@ -2,6 +2,7 @@ import { watch } from "vue";
 import type { ComputedRef, Ref } from "vue";
 import type { ItemDetail, ItemSummary, Settings, VaultSummary } from "../../../types";
 import type { UiSettings } from "../../useUiSettings";
+import { useHardwareKeys } from "../../useHardwareKeys";
 
 type AppWatchersOptions = {
   initialized: ComputedRef<boolean>;
@@ -147,6 +148,26 @@ export function useAppWatchers({
     }
   });
 
+  const hardwareKeys = useHardwareKeys();
+
+  /**
+   * Idle timeout reached. With a hardware key as the unlock source, an inserted
+   * key counts as presence: locking every few minutes while the key sits in the
+   * port only teaches people to switch auto-lock off. Pulling the key locks.
+   *
+   * The presence check is silent and only runs once per idle period, not on
+   * every tick.
+   */
+  const lockIfKeyIsGone = async (value: Settings) => {
+    if (value.unlock_source === "hardware_key" && value.hardware_keys.length > 0) {
+      if (await hardwareKeys.present()) {
+        lastActivityAt.value = Date.now();
+        return;
+      }
+    }
+    await lockSession();
+  };
+
   watch(
     () => settings.value,
     (value) => {
@@ -167,7 +188,7 @@ export function useAppWatchers({
           }
           const elapsed = Date.now() - lastActivityAt.value;
           if (elapsed > value.auto_lock_minutes * 60 * 1000) {
-            void lockSession();
+            void lockIfKeyIsGone(value);
           }
         }, 1000);
       }

--- a/apps/desktop/src/composables/useHardwareKeys.ts
+++ b/apps/desktop/src/composables/useHardwareKeys.ts
@@ -1,0 +1,53 @@
+import { ref } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+import type { ApiResponse, HardwareKeyEntry } from "../types";
+
+/**
+ * Enrolling and using FIDO2 authenticators as the source of the device key.
+ *
+ * Enrolment and unlocking both wait on a physical touch, so callers must keep
+ * the prompt on screen for the whole call — the authenticator gives up after
+ * about 30 seconds and the error comes back as `hardware_key_timeout`.
+ */
+export function useHardwareKeys() {
+  const busy = ref(false);
+  const error = ref("");
+
+  const call = async <T>(command: string, args?: Record<string, unknown>) => {
+    busy.value = true;
+    error.value = "";
+    try {
+      const result = await invoke<ApiResponse<T>>(command, args);
+      if (!result.ok) {
+        error.value = result.error?.kind ?? "hardware_key_error";
+        return null;
+      }
+      return result.data ?? null;
+    } catch (err) {
+      error.value = String(err);
+      return null;
+    } finally {
+      busy.value = false;
+    }
+  };
+
+  const supported = async () => (await call<boolean>("hardware_key_supported")) === true;
+
+  /** Silent: no touch, no prompt. Safe to poll. */
+  const present = async () => (await call<boolean>("hardware_key_present")) === true;
+
+  /** Two touches: one to create the credential, one to prove hmac-secret works. */
+  const enroll = (label: string) =>
+    call<HardwareKeyEntry>("hardware_key_enroll", { label });
+
+  const remove = (credentialId: string) =>
+    call<null>("hardware_key_remove", { credentialId });
+
+  /** One touch. */
+  const unlock = async () => {
+    const result = await call<null>("session_unlock_with_hardware_key");
+    return result !== null || error.value === "";
+  };
+
+  return { busy, error, supported, present, enroll, remove, unlock };
+}

--- a/apps/desktop/src/i18n/locales/en.json
+++ b/apps/desktop/src/i18n/locales/en.json
@@ -251,7 +251,10 @@
     "remember": "Remember unlock on this device",
     "autoUnlock": "Unlock automatically on launch",
     "touchId": "Unlock with Touch ID",
-    "savedUnlock": "Use saved unlock"
+    "savedUnlock": "Use saved unlock",
+    "hardwareKeyPrompt": "Insert your hardware key",
+    "hardwareKeyTouch": "Touch the key…",
+    "hardwareKeyRetry": "Try again"
   },
   "auth": {
     "selectMethod": "How would you like to sign in?",
@@ -434,7 +437,12 @@
       "links": "Links",
       "documentation": "Documentation",
       "sourceCode": "Source Code"
-    }
+    },
+    "unlockSourceKeystore": "System keystore",
+    "unlockSourceHardwareKey": "Hardware key",
+    "hardwareKeyEnrol": "Enrol a key…",
+    "hardwareKeyTouch": "Insert the key and touch it…",
+    "hardwareKeyBackupHint": "Add a backup key too: if the only key is lost, unlocking falls back to the master password."
   },
   "palette": {
     "placeholder": "Type a command...",
@@ -497,7 +505,6 @@
     "rowView": "Row view",
     "jsonView": "JSON view",
     "keyLabel": "Key",
-    "valueLabel": "Value",
     "actionsLabel": "Actions",
     "advanced": "Advanced",
     "customFields": "Custom fields",
@@ -591,7 +598,15 @@
     "time_sync_title": "Time sync required",
     "server_identity_invalid": "Critical security error. The server failed identity verification.",
     "server_identity_missing": "Server identity data is missing. Update the server and try again.",
-    "server_time_skew": "Cannot verify server identity due to time drift (about {minutes} minutes). Check your device clock."
+    "server_time_skew": "Cannot verify server identity due to time drift (about {minutes} minutes). Check your device clock.",
+    "hardware_key_absent": "No enrolled hardware key is connected",
+    "hardware_key_not_enrolled": "This key is not enrolled for this vault",
+    "hardware_key_timeout": "No touch received",
+    "hardware_key_busy": "The key is in use by another application",
+    "hardware_key_unsupported": "This key does not support hmac-secret",
+    "hardware_key_not_accessible": "The key is visible to the system but not accessible",
+    "hardware_key_unsupported_platform": "Hardware keys are not supported on this platform yet",
+    "hardware_key_error": "Hardware key error"
   },
   "time": {
     "never": "Never",

--- a/apps/desktop/src/i18n/locales/ru.json
+++ b/apps/desktop/src/i18n/locales/ru.json
@@ -251,7 +251,10 @@
     "remember": "Запомнить на этом устройстве",
     "autoUnlock": "Авторазблокировка при запуске",
     "touchId": "Разблокировать через Touch ID",
-    "savedUnlock": "Использовать сохранённую разблокировку"
+    "savedUnlock": "Использовать сохранённую разблокировку",
+    "hardwareKeyPrompt": "Вставьте аппаратный ключ",
+    "hardwareKeyTouch": "Коснитесь ключа…",
+    "hardwareKeyRetry": "Повторить"
   },
   "auth": {
     "selectMethod": "Как вы хотите войти?",
@@ -434,7 +437,12 @@
       "links": "Ссылки",
       "documentation": "Документация",
       "sourceCode": "Исходный код"
-    }
+    },
+    "unlockSourceKeystore": "Системное хранилище ключей",
+    "unlockSourceHardwareKey": "Аппаратный ключ",
+    "hardwareKeyEnrol": "Привязать ключ…",
+    "hardwareKeyTouch": "Вставьте ключ и коснитесь его…",
+    "hardwareKeyBackupHint": "Добавьте запасной ключ: если единственный потеряется, останется только мастер-пароль."
   },
   "palette": {
     "placeholder": "Введите команду...",
@@ -497,7 +505,6 @@
     "rowView": "Таблица",
     "jsonView": "JSON",
     "keyLabel": "Ключ",
-    "valueLabel": "Значение",
     "actionsLabel": "Действия",
     "advanced": "Дополнительно",
     "customFields": "Свои поля",
@@ -591,7 +598,15 @@
     "time_sync_title": "Нужна синхронизация времени",
     "server_identity_invalid": "Критическая ошибка безопасности. Сервер не прошел проверку подлинности.",
     "server_identity_missing": "Сервер не передал данные идентификации. Обновите сервер и попробуйте снова.",
-    "server_time_skew": "Не удалось проверить подлинность сервера из-за рассинхронизации времени (≈ {minutes} мин). Проверьте часы на устройстве."
+    "server_time_skew": "Не удалось проверить подлинность сервера из-за рассинхронизации времени (≈ {minutes} мин). Проверьте часы на устройстве.",
+    "hardware_key_absent": "Привязанный аппаратный ключ не подключён",
+    "hardware_key_not_enrolled": "Этот ключ не привязан к хранилищу",
+    "hardware_key_timeout": "Касание не получено",
+    "hardware_key_busy": "Ключ занят другим приложением",
+    "hardware_key_unsupported": "Ключ не поддерживает hmac-secret",
+    "hardware_key_not_accessible": "Ключ виден системе, но недоступен",
+    "hardware_key_unsupported_platform": "Аппаратные ключи пока не поддерживаются на этой платформе",
+    "hardware_key_error": "Ошибка аппаратного ключа"
   },
   "time": {
     "never": "Никогда",

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -12,6 +12,16 @@ export type AppStatus = {
   storages_count: number;
   has_local_vault: boolean;
 };
+export type UnlockSource = "keystore" | "hardware_key";
+
+export type HardwareKeyEntry = {
+  label: string;
+  credential_id: string;
+  salt: string;
+  wrapped_master_key: string;
+  enrolled_at: string;
+};
+
 export type Settings = {
   remember_unlock: boolean;
   auto_unlock: boolean;
@@ -25,6 +35,9 @@ export type Settings = {
   clipboard_clear_if_unchanged: boolean;
   auto_hide_reveal_seconds: number;
   require_os_auth: boolean;
+  /** Where the device key comes from when the unlock is remembered. Exactly one is active. */
+  unlock_source: UnlockSource;
+  hardware_keys: HardwareKeyEntry[];
   /** Master key wrapped by the device key; the device key itself lives in the OS keystore. */
   wrapped_master_key?: string | null;
   trash_auto_purge_days: number;

--- a/crates/zann-ffi/Cargo.toml
+++ b/crates/zann-ffi/Cargo.toml
@@ -23,6 +23,7 @@ zann-core = { path = "../zann-core", features = ["sqlite"] }
 zann-crypto = { path = "../zann-crypto" }
 zann-db = { path = "../zann-db", features = ["sqlite"] }
 zann-client = { path = "../zann-client" }
+zann-keystore = { path = "../zann-keystore" }
 zann-ui-core = { path = "../zann-ui-core" }
 
 [dev-dependencies]

--- a/crates/zann-ffi/Cargo.toml
+++ b/crates/zann-ffi/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+chrono = "0.4"
 uniffi = "0.28"
 uuid = { version = "1", features = ["v7"] }
 zann-core = { path = "../zann-core", features = ["sqlite"] }

--- a/crates/zann-ffi/src/lib.rs
+++ b/crates/zann-ffi/src/lib.rs
@@ -370,11 +370,17 @@ impl CoreFacade {
     }
 
     /// Enrol the connected authenticator against the open vault. Two touches.
-    pub fn enroll_hardware_key(&self, label: String, now: String) -> CoreResult<HardwareKeyFfi> {
+    pub fn enroll_hardware_key(&self, label: String) -> CoreResult<HardwareKeyFfi> {
         let master_key = self.master_key()?;
         let mut remembered = self.load_remembered()?;
+        // The policy crate stays clock-free, so the timestamp is stamped here
+        // rather than trusted from a caller.
         let entry = remembered
-            .enroll_hardware_key(master_key.as_bytes(), &label, now)
+            .enroll_hardware_key(
+                master_key.as_bytes(),
+                &label,
+                chrono::Utc::now().to_rfc3339(),
+            )
             .map_err(unlock_error)?;
         remembered.unlock_source = UnlockSource::HardwareKey;
         self.save_remembered(&remembered)?;

--- a/crates/zann-ffi/src/lib.rs
+++ b/crates/zann-ffi/src/lib.rs
@@ -195,8 +195,8 @@ pub struct CoreFacade {
     vault_id: Mutex<Option<Uuid>>,
     master_key: Mutex<Option<Arc<SecretKey>>>,
     identity: IdentityConfig,
-    /// Where `config.json` lives; the remembered unlock is persisted next to
-    /// the identity so every client on this machine sees the same enrolments.
+    /// The vault directory. The remembered unlock is persisted there in its own
+    /// file, so every client on this machine sees the same enrolments.
     root: PathBuf,
 }
 
@@ -745,55 +745,13 @@ pub fn create_core(db_url: String) -> CoreResult<Arc<CoreFacade>> {
     }))
 }
 
-/// The remembered unlock is stored beside the identity in `config.json`, not in
-/// a per-app file: the OS keystore holds a single device key for this user, so
-/// two clients with separate copies of this state would silently overwrite each
-/// other's.
-const REMEMBERED_KEY: &str = "remembered_unlock";
-
 impl CoreFacade {
-    fn config_path(&self) -> PathBuf {
-        self.root.join("config.json")
-    }
-
     fn load_remembered(&self) -> CoreResult<RememberedUnlock> {
-        let contents = match std::fs::read_to_string(self.config_path()) {
-            Ok(contents) => contents,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(RememberedUnlock::default())
-            }
-            Err(err) => return Err(CoreError::Service(err.to_string())),
-        };
-        let config: Value =
-            serde_json::from_str(&contents).map_err(|err| CoreError::Service(err.to_string()))?;
-        Ok(config
-            .get(REMEMBERED_KEY)
-            .and_then(|value| serde_json::from_value::<RememberedUnlock>(value.clone()).ok())
-            .unwrap_or_default())
+        RememberedUnlock::load(&self.root).map_err(unlock_error)
     }
 
     fn save_remembered(&self, remembered: &RememberedUnlock) -> CoreResult<()> {
-        let path = self.config_path();
-        let mut config: Value = match std::fs::read_to_string(&path) {
-            Ok(contents) => serde_json::from_str(&contents)
-                .map_err(|err| CoreError::Service(err.to_string()))?,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                Value::Object(serde_json::Map::new())
-            }
-            Err(err) => return Err(CoreError::Service(err.to_string())),
-        };
-        let value =
-            serde_json::to_value(remembered).map_err(|err| CoreError::Service(err.to_string()))?;
-        match &mut config {
-            Value::Object(map) => {
-                map.insert(REMEMBERED_KEY.to_string(), value);
-            }
-            other => *other = serde_json::json!({ REMEMBERED_KEY: value }),
-        }
-        std::fs::create_dir_all(&self.root).map_err(|err| CoreError::Service(err.to_string()))?;
-        let json = serde_json::to_string_pretty(&config)
-            .map_err(|err| CoreError::Service(err.to_string()))?;
-        std::fs::write(&path, json).map_err(|err| CoreError::Service(err.to_string()))
+        remembered.save(&self.root).map_err(unlock_error)
     }
 }
 

--- a/crates/zann-ffi/src/lib.rs
+++ b/crates/zann-ffi/src/lib.rs
@@ -15,6 +15,7 @@ use zann_crypto::EncryptedPayload;
 use zann_db::local::{LocalItemRepo, LocalStorage, LocalStorageRepo, LocalVaultRepo};
 use zann_db::services::LocalServices;
 use zann_db::{connect_sqlite_with_max, migrate_local, SqlitePool};
+use zann_keystore::{default_keystore, RememberedUnlock, UnlockError, UnlockSource};
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum CoreError {
@@ -165,6 +166,27 @@ pub struct AppStatusFfi {
     pub has_local_vault: bool,
 }
 
+/// One enrolled authenticator, as the UI needs to show it. The wrapped master
+/// key is deliberately absent: clients list and label keys, they do not handle
+/// key material.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct HardwareKeyFfi {
+    pub label: String,
+    pub credential_id: String,
+    pub enrolled_at: String,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct RememberedUnlockFfi {
+    /// Whether this device can unlock without the master password.
+    pub armed: bool,
+    /// "keystore" or "hardware_key".
+    pub source: String,
+    pub hardware_keys: Vec<HardwareKeyFfi>,
+    /// Whether hardware keys work on this platform at all.
+    pub hardware_supported: bool,
+}
+
 #[derive(uniffi::Object)]
 pub struct CoreFacade {
     runtime: Runtime,
@@ -173,6 +195,9 @@ pub struct CoreFacade {
     vault_id: Mutex<Option<Uuid>>,
     master_key: Mutex<Option<Arc<SecretKey>>>,
     identity: IdentityConfig,
+    /// Where `config.json` lives; the remembered unlock is persisted next to
+    /// the identity so every client on this machine sees the same enrolments.
+    root: PathBuf,
 }
 
 impl CoreFacade {
@@ -206,6 +231,48 @@ impl CoreFacade {
         self.runtime
             .block_on(future)
             .map_err(|err| CoreError::Service(err.to_string()))
+    }
+
+    /// Everything an unlock does once the master key exists, whatever produced
+    /// it. Note the vault-key decryption below doubles as the check that the key
+    /// is the right one, so a key recovered from a stale wrapped copy fails here
+    /// exactly like a wrong password.
+    fn finish_unlock(&self, master_key: Arc<SecretKey>) -> CoreResult<VaultStatus> {
+        let repo = LocalVaultRepo::new(&self.pool);
+        let storage_id = self.storage_id();
+        let vaults = self
+            .runtime
+            .block_on(repo.list_by_storage(storage_id))
+            .map_err(|err| CoreError::Service(err.to_string()))?;
+        let vault_id = if vaults.is_empty() {
+            let services = LocalServices::new(&self.pool, master_key.as_ref());
+            let vault = self.runtime_block_on(services.ensure_default_local_personal())?;
+            vault.id
+        } else {
+            let verify = vaults.first().expect("vaults not empty");
+            vault_crypto::decrypt_vault_key(master_key.as_ref(), verify.id, &verify.vault_key_enc)
+                .map_err(|_| CoreError::InvalidArgument("invalid password".to_string()))?;
+            let item_repo = LocalItemRepo::new(&self.pool);
+            let mut selected = vaults
+                .iter()
+                .find(|vault| vault.is_default)
+                .map(|vault| (vault.id, 0usize))
+                .or_else(|| vaults.first().map(|vault| (vault.id, 0usize)))
+                .expect("vaults not empty");
+            for vault in &vaults {
+                let count = self
+                    .runtime
+                    .block_on(item_repo.count_by_vault(storage_id, vault.id))
+                    .map_err(|err| CoreError::Service(err.to_string()))?;
+                if count as usize > selected.1 {
+                    selected = (vault.id, count as usize);
+                }
+            }
+            selected.0
+        };
+        *self.master_key.lock().expect("lock poisoned") = Some(master_key);
+        *self.vault_id.lock().expect("lock poisoned") = Some(vault_id);
+        Ok(VaultStatus { unlocked: true })
     }
 
     #[cfg(debug_assertions)]
@@ -254,41 +321,94 @@ impl CoreFacade {
 
     pub fn unlock(&self, password: String) -> CoreResult<VaultStatus> {
         let master_key = Arc::new(derive_master_key(&password, &self.identity)?);
-        let repo = LocalVaultRepo::new(&self.pool);
-        let storage_id = self.storage_id();
-        let vaults = self
-            .runtime
-            .block_on(repo.list_by_storage(storage_id))
-            .map_err(|err| CoreError::Service(err.to_string()))?;
-        let vault_id = if vaults.is_empty() {
-            let services = LocalServices::new(&self.pool, master_key.as_ref());
-            let vault = self.runtime_block_on(services.ensure_default_local_personal())?;
-            vault.id
-        } else {
-            let verify = vaults.first().expect("vaults not empty");
-            vault_crypto::decrypt_vault_key(master_key.as_ref(), verify.id, &verify.vault_key_enc)
-                .map_err(|_| CoreError::InvalidArgument("invalid password".to_string()))?;
-            let item_repo = LocalItemRepo::new(&self.pool);
-            let mut selected = vaults
+        self.finish_unlock(master_key)
+    }
+
+    // -- Remembered unlock -------------------------------------------------
+    //
+    // The policy lives in `zann-keystore`; this is the boundary that keeps the
+    // master key on this side of it. Clients ask for an unlock, they never see
+    // or supply key material.
+
+    pub fn remembered_unlock(&self) -> CoreResult<RememberedUnlockFfi> {
+        let remembered = self.load_remembered()?;
+        Ok(RememberedUnlockFfi {
+            armed: remembered.is_armed(),
+            source: match remembered.unlock_source {
+                UnlockSource::Keystore => "keystore".to_string(),
+                UnlockSource::HardwareKey => "hardware_key".to_string(),
+            },
+            hardware_keys: remembered
+                .hardware_keys
                 .iter()
-                .find(|vault| vault.is_default)
-                .map(|vault| (vault.id, 0usize))
-                .or_else(|| vaults.first().map(|vault| (vault.id, 0usize)))
-                .expect("vaults not empty");
-            for vault in &vaults {
-                let count = self
-                    .runtime
-                    .block_on(item_repo.count_by_vault(storage_id, vault.id))
-                    .map_err(|err| CoreError::Service(err.to_string()))?;
-                if count as usize > selected.1 {
-                    selected = (vault.id, count as usize);
-                }
-            }
-            selected.0
-        };
-        *self.master_key.lock().expect("lock poisoned") = Some(master_key);
-        *self.vault_id.lock().expect("lock poisoned") = Some(vault_id);
-        Ok(VaultStatus { unlocked: true })
+                .map(|entry| HardwareKeyFfi {
+                    label: entry.label.clone(),
+                    credential_id: entry.credential_id.clone(),
+                    enrolled_at: entry.enrolled_at.clone(),
+                })
+                .collect(),
+            hardware_supported: cfg!(any(target_os = "linux", target_os = "macos")),
+        })
+    }
+
+    /// Unlock using whichever source this device has armed. Blocks on a touch
+    /// when that source is a hardware key.
+    pub fn unlock_remembered(&self) -> CoreResult<VaultStatus> {
+        let remembered = self.load_remembered()?;
+        let master_key = match remembered.unlock_source {
+            UnlockSource::Keystore => remembered.unlock_with_keystore(default_keystore().as_ref()),
+            UnlockSource::HardwareKey => remembered.unlock_with_hardware_key(),
+        }
+        .map_err(unlock_error)?;
+        self.finish_unlock(Arc::new(SecretKey::from_bytes(master_key)))
+    }
+
+    /// Whether an enrolled authenticator is connected. Silent: no touch, so
+    /// this is safe to poll for auto-lock.
+    pub fn hardware_key_present(&self) -> CoreResult<bool> {
+        Ok(self.load_remembered()?.connected_hardware_key().is_some())
+    }
+
+    /// Enrol the connected authenticator against the open vault. Two touches.
+    pub fn enroll_hardware_key(&self, label: String, now: String) -> CoreResult<HardwareKeyFfi> {
+        let master_key = self.master_key()?;
+        let mut remembered = self.load_remembered()?;
+        let entry = remembered
+            .enroll_hardware_key(master_key.as_bytes(), &label, now)
+            .map_err(unlock_error)?;
+        remembered.unlock_source = UnlockSource::HardwareKey;
+        self.save_remembered(&remembered)?;
+        Ok(HardwareKeyFfi {
+            label: entry.label,
+            credential_id: entry.credential_id,
+            enrolled_at: entry.enrolled_at,
+        })
+    }
+
+    pub fn remove_hardware_key(&self, credential_id: String) -> CoreResult<()> {
+        let mut remembered = self.load_remembered()?;
+        remembered.remove_hardware_key(&credential_id);
+        self.save_remembered(&remembered)
+    }
+
+    /// Remember the unlock in the OS credential store instead.
+    pub fn remember_with_keystore(&self) -> CoreResult<()> {
+        let master_key = self.master_key()?;
+        let mut remembered = self.load_remembered()?;
+        remembered
+            .remember_with_keystore(default_keystore().as_ref(), master_key.as_bytes())
+            .map_err(unlock_error)?;
+        self.save_remembered(&remembered)
+    }
+
+    /// Stop remembering entirely. Enrolled authenticators are left alone: they
+    /// carry their own copies and removing them is a separate, explicit act.
+    pub fn forget_remembered(&self) -> CoreResult<()> {
+        let mut remembered = self.load_remembered()?;
+        remembered
+            .forget_keystore(default_keystore().as_ref())
+            .map_err(unlock_error)?;
+        self.save_remembered(&remembered)
     }
 
     pub fn lock(&self) -> CoreResult<VaultStatus> {
@@ -615,7 +735,69 @@ pub fn create_core(db_url: String) -> CoreResult<Arc<CoreFacade>> {
         vault_id: Mutex::new(None),
         master_key: Mutex::new(None),
         identity,
+        root: local_root_from_db_url(&db_url),
     }))
+}
+
+/// The remembered unlock is stored beside the identity in `config.json`, not in
+/// a per-app file: the OS keystore holds a single device key for this user, so
+/// two clients with separate copies of this state would silently overwrite each
+/// other's.
+const REMEMBERED_KEY: &str = "remembered_unlock";
+
+impl CoreFacade {
+    fn config_path(&self) -> PathBuf {
+        self.root.join("config.json")
+    }
+
+    fn load_remembered(&self) -> CoreResult<RememberedUnlock> {
+        let contents = match std::fs::read_to_string(self.config_path()) {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(RememberedUnlock::default())
+            }
+            Err(err) => return Err(CoreError::Service(err.to_string())),
+        };
+        let config: Value =
+            serde_json::from_str(&contents).map_err(|err| CoreError::Service(err.to_string()))?;
+        Ok(config
+            .get(REMEMBERED_KEY)
+            .and_then(|value| serde_json::from_value::<RememberedUnlock>(value.clone()).ok())
+            .unwrap_or_default())
+    }
+
+    fn save_remembered(&self, remembered: &RememberedUnlock) -> CoreResult<()> {
+        let path = self.config_path();
+        let mut config: Value = match std::fs::read_to_string(&path) {
+            Ok(contents) => serde_json::from_str(&contents)
+                .map_err(|err| CoreError::Service(err.to_string()))?,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                Value::Object(serde_json::Map::new())
+            }
+            Err(err) => return Err(CoreError::Service(err.to_string())),
+        };
+        let value =
+            serde_json::to_value(remembered).map_err(|err| CoreError::Service(err.to_string()))?;
+        match &mut config {
+            Value::Object(map) => {
+                map.insert(REMEMBERED_KEY.to_string(), value);
+            }
+            other => *other = serde_json::json!({ REMEMBERED_KEY: value }),
+        }
+        std::fs::create_dir_all(&self.root).map_err(|err| CoreError::Service(err.to_string()))?;
+        let json = serde_json::to_string_pretty(&config)
+            .map_err(|err| CoreError::Service(err.to_string()))?;
+        std::fs::write(&path, json).map_err(|err| CoreError::Service(err.to_string()))
+    }
+}
+
+/// Unlock failures keep their identifier so every client shows the same message
+/// for the same cause.
+fn unlock_error(err: UnlockError) -> CoreError {
+    match err {
+        UnlockError::NotRemembered => CoreError::InvalidArgument(err.kind().to_string()),
+        other => CoreError::Service(format!("{}: {other}", other.kind())),
+    }
 }
 
 fn client_root_path() -> CoreResult<PathBuf> {

--- a/crates/zann-ffi/tests/remembered_unlock.rs
+++ b/crates/zann-ffi/tests/remembered_unlock.rs
@@ -1,5 +1,7 @@
-//! The remembered unlock shares `config.json` with the identity, so the risk
-//! worth testing is that writing one destroys the other.
+//! The remembered unlock lives in its own file, away from `config.json`. That
+//! separation is the point: `config.json` is written by several typed structs
+//! (the CLI, the client, the desktop) and serde drops fields none of them
+//! model, so an enrolment stored there would vanish on the next write.
 //!
 //! Nothing here needs a credential store or an authenticator: those paths are
 //! covered in `zann-keystore`.
@@ -32,7 +34,7 @@ fn a_fresh_device_has_nothing_remembered() {
 }
 
 #[test]
-fn writing_the_remembered_unlock_leaves_the_identity_intact() {
+fn the_remembered_unlock_is_kept_out_of_config_json() {
     let root = temp_root();
     let db_url = format!("sqlite://{}", root.join("local.sqlite").display());
     let password = format!("test-master-password-{}", Uuid::now_v7());
@@ -48,7 +50,11 @@ fn writing_the_remembered_unlock_leaves_the_identity_intact() {
 
     let config = fs::read_to_string(root.join("config.json")).expect("config.json");
     assert!(config.contains("\"identity\""));
-    assert!(config.contains("\"remembered_unlock\""));
+    assert!(
+        !config.contains("remembered_unlock"),
+        "config.json is shared with clients that would drop this field"
+    );
+    assert!(root.join("unlock.json").exists());
 
     // The identity still derives the same master key, which is the property the
     // whole vault hangs on.

--- a/crates/zann-ffi/tests/remembered_unlock.rs
+++ b/crates/zann-ffi/tests/remembered_unlock.rs
@@ -1,0 +1,59 @@
+//! The remembered unlock shares `config.json` with the identity, so the risk
+//! worth testing is that writing one destroys the other.
+//!
+//! Nothing here needs a credential store or an authenticator: those paths are
+//! covered in `zann-keystore`.
+
+use std::fs;
+use std::path::PathBuf;
+
+use uuid::Uuid;
+use zann_ffi::create_core;
+
+fn temp_root() -> PathBuf {
+    let root = std::env::temp_dir().join(format!("zann-ffi-remembered-{}", Uuid::now_v7()));
+    fs::create_dir_all(&root).expect("create temp dir");
+    root
+}
+
+#[test]
+fn a_fresh_device_has_nothing_remembered() {
+    let root = temp_root();
+    let db_url = format!("sqlite://{}", root.join("local.sqlite").display());
+
+    let core = create_core(db_url).expect("create core");
+    let remembered = core.remembered_unlock().expect("status");
+
+    assert!(!remembered.armed);
+    assert_eq!(remembered.source, "keystore");
+    assert!(remembered.hardware_keys.is_empty());
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn writing_the_remembered_unlock_leaves_the_identity_intact() {
+    let root = temp_root();
+    let db_url = format!("sqlite://{}", root.join("local.sqlite").display());
+    let password = format!("test-master-password-{}", Uuid::now_v7());
+
+    let core = create_core(db_url.clone()).expect("create core");
+    core.initialize_master_password(password.clone())
+        .expect("initialize master password");
+
+    // Rewrites config.json through the remembered-unlock path.
+    core.remove_hardware_key("not-enrolled".to_string())
+        .expect("remove is a no-op");
+    drop(core);
+
+    let config = fs::read_to_string(root.join("config.json")).expect("config.json");
+    assert!(config.contains("\"identity\""));
+    assert!(config.contains("\"remembered_unlock\""));
+
+    // The identity still derives the same master key, which is the property the
+    // whole vault hangs on.
+    let core = create_core(db_url).expect("reopen core");
+    assert!(core.unlock(password).expect("unlock").unlocked);
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/zann-keystore/Cargo.toml
+++ b/crates/zann-keystore/Cargo.toml
@@ -7,8 +7,19 @@ license = "MIT"
 [dependencies]
 anyhow = "1"
 base64 = "0.22"
+blake3 = "1"
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
+zann-crypto = { path = "../zann-crypto" }
+
+[dev-dependencies]
+serde_json = "1"
+
+# FIDO2 over raw HID. Linux and macOS only: on Windows a non-elevated process
+# cannot reach the device this way and has to go through webauthn.dll.
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+ctap-hid-fido2 = "3.5"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 keyring = "2"

--- a/crates/zann-keystore/Cargo.toml
+++ b/crates/zann-keystore/Cargo.toml
@@ -21,3 +21,6 @@ ctap-hid-fido2 = "3.5"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 keyring = "2"
+
+[dev-dependencies]
+rand = "0.8"

--- a/crates/zann-keystore/Cargo.toml
+++ b/crates/zann-keystore/Cargo.toml
@@ -10,11 +10,9 @@ base64 = "0.22"
 blake3 = "1"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "1"
 zann-crypto = { path = "../zann-crypto" }
-
-[dev-dependencies]
-serde_json = "1"
 
 # FIDO2 over raw HID. Linux and macOS only: on Windows a non-elevated process
 # cannot reach the device this way and has to go through webauthn.dll.

--- a/crates/zann-keystore/src/fido.rs
+++ b/crates/zann-keystore/src/fido.rs
@@ -1,0 +1,239 @@
+//! Device wrapping keys derived from a FIDO2 authenticator.
+//!
+//! Unlike the OS credential store, nothing is *stored* here: the key is
+//! recomputed from the authenticator's `hmac-secret` extension on every unlock.
+//! What lands on disk is only `credential_id` and `salt`, neither of which is
+//! secret and neither of which is useful without the physical token.
+//!
+//! Credentials are non-discoverable and require user presence (a touch) but not
+//! user verification (a PIN): this is an optional convenience over the master
+//! password, so a PIN on every unlock is the wrong trade. The token's own
+//! discoverable-credential slots stay free for other uses.
+
+use ctap_hid_fido2::fidokey::{
+    get_assertion::get_assertion_params::{Extension as Aext, GetAssertionArgsBuilder},
+    make_credential::make_credential_params::{Extension as Mext, MakeCredentialArgsBuilder},
+    FidoKeyHid,
+};
+use ctap_hid_fido2::{Cfg, FidoKeyHidFactory};
+use serde::{Deserialize, Serialize};
+
+/// Relying party the credentials are scoped to. Changing this orphans every
+/// enrolled key, so it is deliberately not configurable.
+const RP_ID: &str = "zann.local";
+
+/// Domain separation for the KDF applied to the authenticator's output.
+const DWK_CONTEXT: &str = "zann 2026-08-08 fido2 device wrapping key";
+
+/// The authenticator itself gives up after ~30s of waiting for a touch, so any
+/// UI timeout has to be at least this generous.
+pub const TOUCH_TIMEOUT_SECS: u64 = 30;
+
+/// What has to be remembered to derive a DWK again. Not secret.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HardwareCredential {
+    pub credential_id: Vec<u8>,
+    pub salt: [u8; 32],
+}
+
+#[derive(thiserror::Error, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum FidoError {
+    #[error("no authenticator connected")]
+    NoDevice,
+    #[error("the connected authenticator is not enrolled for this vault")]
+    NotEnrolled,
+    #[error("no touch received")]
+    Timeout,
+    #[error("the authenticator is in use by another application")]
+    Busy,
+    #[error("this authenticator does not support hmac-secret")]
+    NoHmacSecret,
+    #[error("the authenticator is connected but not accessible; check the udev rules")]
+    NotAccessible,
+    #[error("authenticator error: {message}")]
+    Internal { message: String },
+}
+
+impl FidoError {
+    /// Stable identifier for the UI to translate; the variants map one-to-one
+    /// onto the states a user can actually act on.
+    #[must_use]
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::NoDevice => "hardware_key_absent",
+            Self::NotEnrolled => "hardware_key_not_enrolled",
+            Self::Timeout => "hardware_key_timeout",
+            Self::Busy => "hardware_key_busy",
+            Self::NoHmacSecret => "hardware_key_unsupported",
+            Self::NotAccessible => "hardware_key_not_accessible",
+            Self::Internal { .. } => "hardware_key_error",
+        }
+    }
+}
+
+fn cfg() -> Cfg {
+    let mut cfg = Cfg::init();
+    // The crate otherwise prints "- Touch the sensor..." straight to stdout.
+    // Prompting is the UI's job.
+    cfg.keep_alive_msg = String::new();
+    cfg.enable_log = false;
+    cfg
+}
+
+fn open() -> Result<FidoKeyHid, FidoError> {
+    FidoKeyHidFactory::create(&cfg()).map_err(|err| classify(&err.to_string()))
+}
+
+/// The crate surfaces CTAP status codes only inside formatted messages, so the
+/// taxonomy has to be recovered from the text. Kept in one place, and covered
+/// by tests, because it drives what the user is told to do.
+fn classify(message: &str) -> FidoError {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("0x2e") || lower.contains("no_credentials") {
+        FidoError::NotEnrolled
+    } else if lower.contains("0x27") || lower.contains("operation_denied") {
+        // The authenticator reports a touch that never came the same way it
+        // reports one the user actively declined.
+        FidoError::Timeout
+    } else if lower.contains("0x33") || lower.contains("unsupported_extension") {
+        FidoError::NoHmacSecret
+    } else if lower.contains("device not found") || lower.contains("no device") {
+        FidoError::NoDevice
+    } else if lower.contains("permission denied") || lower.contains("access denied") {
+        FidoError::NotAccessible
+    } else if lower.contains("busy") || lower.contains("in use") {
+        FidoError::Busy
+    } else {
+        FidoError::Internal {
+            message: message.to_string(),
+        }
+    }
+}
+
+/// Whether any authenticator is reachable at all. Distinguishes "nothing
+/// plugged in" from "plugged in but the process cannot open it", which are
+/// different problems with different fixes.
+pub fn authenticator_status() -> Result<(), FidoError> {
+    if ctap_hid_fido2::get_fidokey_devices().is_empty() {
+        return Err(FidoError::NoDevice);
+    }
+    open().map(|_| ())
+}
+
+/// Create a credential on the connected authenticator and return it together
+/// with the key it derives. Costs two touches: one to create, one to prove the
+/// authenticator really honours `hmac-secret`, so a token that silently ignored
+/// the extension fails here rather than at the first unlock.
+pub fn enroll(salt: [u8; 32]) -> Result<(HardwareCredential, [u8; 32]), FidoError> {
+    let device = open()?;
+    let args = MakeCredentialArgsBuilder::new(RP_ID, &challenge())
+        .without_pin_and_uv()
+        .extensions(&[Mext::HmacSecret(Some(true))])
+        .build();
+    let attestation = device
+        .make_credential_with_args(&args)
+        .map_err(|err| classify(&err.to_string()))?;
+
+    let credential = HardwareCredential {
+        credential_id: attestation.credential_descriptor.id.clone(),
+        salt,
+    };
+
+    let dwk = derive_dwk_with(&device, &credential)?;
+    Ok((credential, dwk))
+}
+
+/// Derive the device wrapping key. Requires a touch.
+pub fn derive_dwk(credential: &HardwareCredential) -> Result<[u8; 32], FidoError> {
+    let device = open()?;
+    derive_dwk_with(&device, credential)
+}
+
+fn derive_dwk_with(
+    device: &FidoKeyHid,
+    credential: &HardwareCredential,
+) -> Result<[u8; 32], FidoError> {
+    let args = GetAssertionArgsBuilder::new(RP_ID, &challenge())
+        .without_pin_and_uv()
+        .credential_id(&credential.credential_id)
+        .extensions(&[Aext::HmacSecret(Some(credential.salt))])
+        .build();
+    let assertions = device
+        .get_assertion_with_args(&args)
+        .map_err(|err| classify(&err.to_string()))?;
+
+    let output = assertions
+        .iter()
+        .flat_map(|assertion| assertion.extensions.iter())
+        .find_map(|extension| match extension {
+            Aext::HmacSecret(Some(value)) => Some(*value),
+            _ => None,
+        })
+        .ok_or(FidoError::NoHmacSecret)?;
+
+    Ok(derive_key(&output))
+}
+
+/// Whether *this* credential's authenticator is connected, without asking the
+/// user for anything. A silent assertion answers in ~170ms and, unlike probing
+/// for any FIDO device, cannot be satisfied by some unrelated token.
+#[must_use]
+pub fn is_present(credential: &HardwareCredential) -> bool {
+    let Ok(device) = open() else {
+        return false;
+    };
+    let args = GetAssertionArgsBuilder::new(RP_ID, &challenge())
+        .without_pin_and_uv()
+        .without_up()
+        .credential_id(&credential.credential_id)
+        .build();
+    device.get_assertion_with_args(&args).is_ok()
+}
+
+/// The authenticator signs this, and nobody verifies the signature: the secret
+/// comes from the extension, not from the assertion. A constant keeps the
+/// derivation reproducible.
+fn challenge() -> [u8; 32] {
+    [0u8; 32]
+}
+
+fn derive_key(hmac_output: &[u8; 32]) -> [u8; 32] {
+    blake3::derive_key(DWK_CONTEXT, hmac_output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ctap_status_codes_map_to_actionable_errors() {
+        assert_eq!(
+            classify("response_status err = 0x2E CTAP2_ERR_NO_CREDENTIALS"),
+            FidoError::NotEnrolled
+        );
+        assert_eq!(
+            classify("response_status err = 0x27 CTAP2_ERR_OPERATION_DENIED"),
+            FidoError::Timeout
+        );
+        assert_eq!(
+            classify("response_status err = 0x33 CTAP2_ERR_UNSUPPORTED_EXTENSION"),
+            FidoError::NoHmacSecret
+        );
+        assert!(matches!(
+            classify("something we have never seen"),
+            FidoError::Internal { .. }
+        ));
+    }
+
+    #[test]
+    fn derivation_is_deterministic_and_not_the_raw_authenticator_output() {
+        let output = [9u8; 32];
+        let key = derive_key(&output);
+        assert_eq!(key, derive_key(&output));
+        assert_ne!(
+            key, output,
+            "the raw hmac output must not be used as the DWK"
+        );
+        assert_ne!(key, derive_key(&[8u8; 32]));
+    }
+}

--- a/crates/zann-keystore/src/lib.rs
+++ b/crates/zann-keystore/src/lib.rs
@@ -56,9 +56,14 @@ pub trait Keystore: Send + Sync {
     fn delete_dwk(&self) -> Result<(), KeystoreError>;
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub mod fido;
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 mod keyring_store;
+pub mod remembered;
 mod unsupported;
+
+pub use remembered::{HardwareKeyEntry, RememberedUnlock, UnlockError, UnlockSource};
 
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 pub use keyring_store::KeyringKeystore;

--- a/crates/zann-keystore/src/remembered.rs
+++ b/crates/zann-keystore/src/remembered.rs
@@ -11,10 +11,18 @@
 //! What this module deliberately does not do: hold the master key, prompt the
 //! user, or touch a settings file. Callers own all three.
 
+use std::path::{Path, PathBuf};
+
 use serde::{Deserialize, Serialize};
 use zann_crypto::crypto::{decrypt_blob, encrypt_blob, EncryptedBlob, SecretKey};
 
 use crate::{Keystore, KeystoreError};
+
+/// The remembered unlock lives in its own file, not in `config.json`, because
+/// that one is written by several typed structs (the CLI, the client, the
+/// desktop) and serde drops fields none of them model — an enrolment made by
+/// one client would vanish on the next write by another.
+pub const FILENAME: &str = "unlock.json";
 
 /// Additional authenticated data binding a wrapped master key to this purpose.
 /// Part of the on-disk format: changing it invalidates every remembered unlock.
@@ -90,6 +98,17 @@ impl UnlockError {
     }
 }
 
+/// Nothing here is secret — the wrapped keys are ciphertext — but a file that
+/// says which authenticators open this vault is nobody else's business.
+#[cfg(unix)]
+fn restrict(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn restrict(_path: &Path) {}
+
 fn corrupt(message: impl Into<String>) -> UnlockError {
     UnlockError::Corrupt {
         message: message.into(),
@@ -129,6 +148,30 @@ impl RememberedUnlock {
             UnlockSource::Keystore => self.wrapped_master_key.is_some(),
             UnlockSource::HardwareKey => !self.hardware_keys.is_empty(),
         }
+    }
+
+    #[must_use]
+    pub fn path(root: &Path) -> PathBuf {
+        root.join(FILENAME)
+    }
+
+    /// Read what this device remembers. A missing file is a device that
+    /// remembers nothing, not an error.
+    pub fn load(root: &Path) -> Result<Self, UnlockError> {
+        match std::fs::read_to_string(Self::path(root)) {
+            Ok(contents) => serde_json::from_str(&contents).map_err(|err| corrupt(err.to_string())),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(err) => Err(corrupt(err.to_string())),
+        }
+    }
+
+    pub fn save(&self, root: &Path) -> Result<(), UnlockError> {
+        std::fs::create_dir_all(root).map_err(|err| corrupt(err.to_string()))?;
+        let json = serde_json::to_string_pretty(self).map_err(|err| corrupt(err.to_string()))?;
+        let path = Self::path(root);
+        std::fs::write(&path, json).map_err(|err| corrupt(err.to_string()))?;
+        restrict(&path);
+        Ok(())
     }
 
     // -- OS keystore ------------------------------------------------------
@@ -464,5 +507,59 @@ mod tests {
         assert!(json.contains("\"unlock_source\":\"keystore\""));
         assert!(json.contains("\"hardware_keys\":[]"));
         assert!(json.contains("\"wrapped_master_key\":null"));
+    }
+}
+
+#[cfg(test)]
+mod file_tests {
+    use super::*;
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("zann-unlock-{}-{}", name, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn a_device_with_no_file_remembers_nothing() {
+        let root = scratch("missing");
+        let remembered = RememberedUnlock::load(&root).expect("load");
+        assert!(!remembered.is_armed());
+    }
+
+    #[test]
+    fn state_survives_a_round_trip_through_the_file() {
+        let root = scratch("round-trip");
+        let remembered = RememberedUnlock {
+            unlock_source: UnlockSource::HardwareKey,
+            hardware_keys: vec![HardwareKeyEntry {
+                label: "YubiKey".to_string(),
+                credential_id: "Y2lk".to_string(),
+                salt: "c2FsdA==".to_string(),
+                wrapped_master_key: "d3JhcHBlZA==".to_string(),
+                enrolled_at: "2026-08-08T00:00:00Z".to_string(),
+            }],
+            wrapped_master_key: None,
+        };
+
+        remembered.save(&root).expect("save");
+        assert_eq!(RememberedUnlock::load(&root).expect("load"), remembered);
+
+        // The file is ours alone: no other client's typed config can drop
+        // fields it does not model.
+        assert!(RememberedUnlock::path(&root).ends_with("unlock.json"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = scratch("perms");
+        RememberedUnlock::default().save(&root).expect("save");
+        let mode = std::fs::metadata(RememberedUnlock::path(&root))
+            .expect("metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
     }
 }

--- a/crates/zann-keystore/src/remembered.rs
+++ b/crates/zann-keystore/src/remembered.rs
@@ -1,0 +1,468 @@
+//! Remembering the unlock on a device, independent of any UI toolkit.
+//!
+//! The master key is wrapped with a device wrapping key (DWK) that never lands
+//! in application files. Where the DWK comes from is the choice this module
+//! owns: the OS credential store, or a FIDO2 authenticator that re-derives it on
+//! every unlock.
+//!
+//! Exactly one source is active at a time. With both live the keystore would
+//! always answer first and the hardware key would be decoration.
+//!
+//! What this module deliberately does not do: hold the master key, prompt the
+//! user, or touch a settings file. Callers own all three.
+
+use serde::{Deserialize, Serialize};
+use zann_crypto::crypto::{decrypt_blob, encrypt_blob, EncryptedBlob, SecretKey};
+
+use crate::{Keystore, KeystoreError};
+
+/// Additional authenticated data binding a wrapped master key to this purpose.
+/// Part of the on-disk format: changing it invalidates every remembered unlock.
+pub const DWK_AAD: &[u8] = b"zann:dwk:wrap:v1";
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum UnlockSource {
+    #[default]
+    Keystore,
+    HardwareKey,
+}
+
+/// One enrolled authenticator. Nothing here is secret on its own: the wrapped
+/// key needs the token, and the token needs a touch.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct HardwareKeyEntry {
+    pub label: String,
+    /// Base64. Identifies the credential to the authenticator.
+    pub credential_id: String,
+    /// Base64. Salt fed to `hmac-secret`; different salts give different keys.
+    pub salt: String,
+    /// Base64. This token's own copy of the master key.
+    pub wrapped_master_key: String,
+    pub enrolled_at: String,
+}
+
+/// The part of a client's settings that describes a remembered unlock. Meant to
+/// be flattened into whatever settings struct a client already persists, so the
+/// on-disk field names stay stable across clients.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[serde(default)]
+pub struct RememberedUnlock {
+    pub unlock_source: UnlockSource,
+    pub hardware_keys: Vec<HardwareKeyEntry>,
+    /// Used by [`UnlockSource::Keystore`]; hardware keys carry their own copies.
+    pub wrapped_master_key: Option<String>,
+}
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum UnlockError {
+    #[error("no remembered unlock on this device")]
+    NotRemembered,
+    #[error("keystore: {0}")]
+    Keystore(#[from] KeystoreError),
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[error("hardware key: {0}")]
+    HardwareKey(#[from] crate::fido::FidoError),
+    #[error("stored unlock data is corrupt: {message}")]
+    Corrupt { message: String },
+    #[error("hardware keys are not supported on this platform yet")]
+    UnsupportedPlatform,
+}
+
+impl UnlockError {
+    /// Stable identifier for the UI to translate. Clients must not parse the
+    /// message text.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::NotRemembered => "keystore_not_found",
+            Self::Keystore(err) => match err {
+                KeystoreError::Cancelled => "keystore_cancelled",
+                KeystoreError::NotFound => "keystore_not_found",
+                KeystoreError::Unsupported => "keystore_unsupported",
+                KeystoreError::Internal { .. } => "keystore_unavailable",
+            },
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            Self::HardwareKey(err) => err.kind(),
+            Self::Corrupt { .. } => "keystore_error",
+            Self::UnsupportedPlatform => "hardware_key_unsupported_platform",
+        }
+    }
+}
+
+fn corrupt(message: impl Into<String>) -> UnlockError {
+    UnlockError::Corrupt {
+        message: message.into(),
+    }
+}
+
+fn b64() -> base64::engine::general_purpose::GeneralPurpose {
+    base64::engine::general_purpose::STANDARD
+}
+
+fn wrap(dwk: &[u8; 32], master_key: &[u8; 32]) -> Result<String, UnlockError> {
+    use base64::Engine;
+    let blob = encrypt_blob(&SecretKey::from_bytes(*dwk), master_key, DWK_AAD)
+        .map_err(|err| corrupt(err.to_string()))?;
+    Ok(b64().encode(blob.to_bytes()))
+}
+
+fn unwrap(dwk: &[u8; 32], wrapped: &str) -> Result<[u8; 32], UnlockError> {
+    use base64::Engine;
+    let bytes = b64()
+        .decode(wrapped)
+        .map_err(|err| corrupt(err.to_string()))?;
+    let blob = EncryptedBlob::from_bytes(&bytes).map_err(|err| corrupt(err.to_string()))?;
+    let master = decrypt_blob(&SecretKey::from_bytes(*dwk), &blob, DWK_AAD)
+        .map_err(|err| corrupt(err.to_string()))?;
+    master
+        .as_slice()
+        .try_into()
+        .map_err(|_| corrupt("unwrapped master key has the wrong length"))
+}
+
+impl RememberedUnlock {
+    /// Whether anything can unlock this device without the master password.
+    #[must_use]
+    pub fn is_armed(&self) -> bool {
+        match self.unlock_source {
+            UnlockSource::Keystore => self.wrapped_master_key.is_some(),
+            UnlockSource::HardwareKey => !self.hardware_keys.is_empty(),
+        }
+    }
+
+    // -- OS keystore ------------------------------------------------------
+
+    pub fn remember_with_keystore(
+        &mut self,
+        keystore: &dyn Keystore,
+        master_key: &[u8; 32],
+    ) -> Result<(), UnlockError> {
+        let dwk = SecretKey::generate();
+        keystore.store_dwk(dwk.as_bytes())?;
+        self.wrapped_master_key = Some(wrap(dwk.as_bytes(), master_key)?);
+        self.unlock_source = UnlockSource::Keystore;
+        Ok(())
+    }
+
+    pub fn unlock_with_keystore(&self, keystore: &dyn Keystore) -> Result<[u8; 32], UnlockError> {
+        let wrapped = self
+            .wrapped_master_key
+            .as_deref()
+            .ok_or(UnlockError::NotRemembered)?;
+        let dwk: [u8; 32] = keystore
+            .load_dwk()?
+            .ok_or(UnlockError::NotRemembered)?
+            .as_slice()
+            .try_into()
+            .map_err(|_| corrupt("stored device key has the wrong length"))?;
+        unwrap(&dwk, wrapped)
+    }
+
+    /// Forget the keystore copy. Tolerates a store that never held one, so it
+    /// is safe to call when switching sources.
+    pub fn forget_keystore(&mut self, keystore: &dyn Keystore) -> Result<(), UnlockError> {
+        self.wrapped_master_key = None;
+        match keystore.delete_dwk() {
+            Ok(()) | Err(KeystoreError::NotFound | KeystoreError::Unsupported) => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Move a device key that an older version left in a settings file into the
+    /// keystore. Returns whether the caller still has a usable remembered
+    /// unlock: on failure there is nowhere safe to keep the key, so the state
+    /// is cleared rather than left readable on disk.
+    pub fn adopt_legacy_dwk(
+        &mut self,
+        keystore: &dyn Keystore,
+        legacy_dwk: &str,
+    ) -> Result<(), UnlockError> {
+        use base64::Engine;
+        let result = b64()
+            .decode(legacy_dwk)
+            .map_err(|err| corrupt(err.to_string()))
+            .and_then(|dwk| keystore.store_dwk(&dwk).map_err(UnlockError::from));
+        if result.is_err() {
+            self.wrapped_master_key = None;
+        }
+        result
+    }
+
+    // -- Hardware keys ----------------------------------------------------
+
+    pub fn remove_hardware_key(&mut self, credential_id: &str) {
+        self.hardware_keys
+            .retain(|entry| entry.credential_id != credential_id);
+        if self.hardware_keys.is_empty() && self.unlock_source == UnlockSource::HardwareKey {
+            self.unlock_source = UnlockSource::Keystore;
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl RememberedUnlock {
+    /// Enrol the connected authenticator. Two touches; see [`crate::fido`].
+    /// `enrolled_at` is passed in so this crate needs no clock.
+    pub fn enroll_hardware_key(
+        &mut self,
+        master_key: &[u8; 32],
+        label: &str,
+        enrolled_at: String,
+    ) -> Result<HardwareKeyEntry, UnlockError> {
+        use base64::Engine;
+        use rand::{rngs::OsRng, RngCore};
+
+        let mut salt = [0u8; 32];
+        OsRng.fill_bytes(&mut salt);
+
+        let (credential, dwk) = crate::fido::enroll(salt)?;
+        let entry = HardwareKeyEntry {
+            label: if label.trim().is_empty() {
+                "Hardware key".to_string()
+            } else {
+                label.trim().to_string()
+            },
+            credential_id: b64().encode(&credential.credential_id),
+            salt: b64().encode(credential.salt),
+            wrapped_master_key: wrap(&dwk, master_key)?,
+            enrolled_at,
+        };
+
+        // Re-enrolling a token replaces its entry rather than piling up copies
+        // that all open the same door.
+        self.hardware_keys
+            .retain(|existing| existing.credential_id != entry.credential_id);
+        self.hardware_keys.push(entry.clone());
+        Ok(entry)
+    }
+
+    /// The enrolled entry whose authenticator is plugged in, if any. Silent: no
+    /// touch, so this is safe to poll for auto-lock.
+    #[must_use]
+    pub fn connected_hardware_key(&self) -> Option<&HardwareKeyEntry> {
+        self.hardware_keys.iter().find(|entry| {
+            credential(entry)
+                .map(|credential| crate::fido::is_present(&credential))
+                .unwrap_or(false)
+        })
+    }
+
+    /// One touch, on whichever enrolled token is connected.
+    pub fn unlock_with_hardware_key(&self) -> Result<[u8; 32], UnlockError> {
+        if self.hardware_keys.is_empty() {
+            return Err(UnlockError::NotRemembered);
+        }
+        let entry = self
+            .connected_hardware_key()
+            .ok_or(UnlockError::HardwareKey(crate::fido::FidoError::NoDevice))?;
+        let dwk = crate::fido::derive_dwk(&credential(entry)?)?;
+        unwrap(&dwk, &entry.wrapped_master_key)
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+impl RememberedUnlock {
+    pub fn enroll_hardware_key(
+        &mut self,
+        _master_key: &[u8; 32],
+        _label: &str,
+        _enrolled_at: String,
+    ) -> Result<HardwareKeyEntry, UnlockError> {
+        Err(UnlockError::UnsupportedPlatform)
+    }
+
+    #[must_use]
+    pub fn connected_hardware_key(&self) -> Option<&HardwareKeyEntry> {
+        None
+    }
+
+    pub fn unlock_with_hardware_key(&self) -> Result<[u8; 32], UnlockError> {
+        Err(UnlockError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn credential(entry: &HardwareKeyEntry) -> Result<crate::fido::HardwareCredential, UnlockError> {
+    use base64::Engine;
+    let credential_id = b64()
+        .decode(&entry.credential_id)
+        .map_err(|err| corrupt(err.to_string()))?;
+    let salt: [u8; 32] = b64()
+        .decode(&entry.salt)
+        .map_err(|err| corrupt(err.to_string()))?
+        .as_slice()
+        .try_into()
+        .map_err(|_| corrupt("stored salt has the wrong length"))?;
+    Ok(crate::fido::HardwareCredential {
+        credential_id,
+        salt,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct FakeKeystore {
+        stored: Mutex<Option<Vec<u8>>>,
+        broken: bool,
+    }
+
+    impl FakeKeystore {
+        fn working() -> Self {
+            Self {
+                stored: Mutex::new(None),
+                broken: false,
+            }
+        }
+
+        fn broken() -> Self {
+            Self {
+                stored: Mutex::new(None),
+                broken: true,
+            }
+        }
+    }
+
+    impl Keystore for FakeKeystore {
+        fn status(&self) -> crate::KeystoreStatus {
+            crate::KeystoreStatus {
+                supported: !self.broken,
+                biometrics_available: false,
+                reason: None,
+                message: None,
+            }
+        }
+
+        fn store_dwk(&self, dwk: &[u8]) -> Result<(), KeystoreError> {
+            if self.broken {
+                return Err(KeystoreError::Unsupported);
+            }
+            *self.stored.lock().unwrap() = Some(dwk.to_vec());
+            Ok(())
+        }
+
+        fn load_dwk(&self) -> Result<Option<Vec<u8>>, KeystoreError> {
+            if self.broken {
+                return Err(KeystoreError::Unsupported);
+            }
+            Ok(self.stored.lock().unwrap().clone())
+        }
+
+        fn delete_dwk(&self) -> Result<(), KeystoreError> {
+            *self.stored.lock().unwrap() = None;
+            Ok(())
+        }
+    }
+
+    const MASTER: [u8; 32] = [5u8; 32];
+
+    #[test]
+    fn keystore_round_trip_returns_the_same_master_key() {
+        let keystore = FakeKeystore::working();
+        let mut remembered = RememberedUnlock::default();
+        assert!(!remembered.is_armed());
+
+        remembered
+            .remember_with_keystore(&keystore, &MASTER)
+            .expect("remember");
+        assert!(remembered.is_armed());
+        assert_eq!(
+            remembered.unlock_with_keystore(&keystore).expect("unlock"),
+            MASTER
+        );
+    }
+
+    #[test]
+    fn the_wrapped_key_is_useless_without_the_device_key() {
+        let keystore = FakeKeystore::working();
+        let mut remembered = RememberedUnlock::default();
+        remembered
+            .remember_with_keystore(&keystore, &MASTER)
+            .expect("remember");
+
+        // Same settings, empty store: this is the "someone copied the settings
+        // file" case, and it must not yield the master key.
+        let stolen_file = remembered.clone();
+        let empty_store = FakeKeystore::working();
+        assert!(stolen_file.unlock_with_keystore(&empty_store).is_err());
+    }
+
+    #[test]
+    fn forgetting_clears_both_halves() {
+        let keystore = FakeKeystore::working();
+        let mut remembered = RememberedUnlock::default();
+        remembered
+            .remember_with_keystore(&keystore, &MASTER)
+            .expect("remember");
+
+        remembered.forget_keystore(&keystore).expect("forget");
+        assert!(remembered.wrapped_master_key.is_none());
+        assert_eq!(keystore.load_dwk().unwrap(), None);
+        assert!(!remembered.is_armed());
+    }
+
+    #[test]
+    fn adopting_a_legacy_key_keeps_the_unlock_working() {
+        use base64::Engine;
+        let keystore = FakeKeystore::working();
+        let dwk = [3u8; 32];
+        let mut remembered = RememberedUnlock {
+            wrapped_master_key: Some(wrap(&dwk, &MASTER).expect("wrap")),
+            ..RememberedUnlock::default()
+        };
+
+        remembered
+            .adopt_legacy_dwk(&keystore, &b64().encode(dwk))
+            .expect("adopt");
+        assert_eq!(
+            remembered.unlock_with_keystore(&keystore).expect("unlock"),
+            MASTER
+        );
+    }
+
+    #[test]
+    fn a_legacy_key_with_nowhere_to_go_is_dropped_rather_than_kept() {
+        use base64::Engine;
+        let dwk = [3u8; 32];
+        let mut remembered = RememberedUnlock {
+            wrapped_master_key: Some(wrap(&dwk, &MASTER).expect("wrap")),
+            ..RememberedUnlock::default()
+        };
+
+        let result = remembered.adopt_legacy_dwk(&FakeKeystore::broken(), &b64().encode(dwk));
+        assert!(result.is_err());
+        assert!(remembered.wrapped_master_key.is_none());
+        assert!(!remembered.is_armed());
+    }
+
+    #[test]
+    fn removing_the_last_hardware_key_falls_back_to_the_keystore_source() {
+        let mut remembered = RememberedUnlock {
+            unlock_source: UnlockSource::HardwareKey,
+            hardware_keys: vec![HardwareKeyEntry {
+                label: "YubiKey".to_string(),
+                credential_id: "abc".to_string(),
+                salt: "def".to_string(),
+                wrapped_master_key: "ghi".to_string(),
+                enrolled_at: "2026-08-08T00:00:00Z".to_string(),
+            }],
+            wrapped_master_key: None,
+        };
+
+        remembered.remove_hardware_key("abc");
+        assert!(remembered.hardware_keys.is_empty());
+        assert_eq!(remembered.unlock_source, UnlockSource::Keystore);
+        assert!(!remembered.is_armed());
+    }
+
+    #[test]
+    fn settings_keep_their_on_disk_field_names() {
+        let json = serde_json::to_string(&RememberedUnlock::default()).expect("serialize");
+        assert!(json.contains("\"unlock_source\":\"keystore\""));
+        assert!(json.contains("\"hardware_keys\":[]"));
+        assert!(json.contains("\"wrapped_master_key\":null"));
+    }
+}

--- a/crates/zann-keystore/src/remembered.rs
+++ b/crates/zann-keystore/src/remembered.rs
@@ -254,10 +254,10 @@ impl RememberedUnlock {
         enrolled_at: String,
     ) -> Result<HardwareKeyEntry, UnlockError> {
         use base64::Engine;
-        use rand::{rngs::OsRng, RngCore};
 
-        let mut salt = [0u8; 32];
-        OsRng.fill_bytes(&mut salt);
+        // A fresh salt per enrolment: the same authenticator then derives a
+        // different key for every vault it is enrolled in.
+        let salt: [u8; 32] = rand::random();
 
         let (credential, dwk) = crate::fido::enroll(salt)?;
         let entry = HardwareKeyEntry {

--- a/crates/zann-keystore/tests/fido_authenticator.rs
+++ b/crates/zann-keystore/tests/fido_authenticator.rs
@@ -19,7 +19,8 @@ fn enrols_derives_and_detects_the_authenticator() {
     fido::authenticator_status().expect("an authenticator must be connected");
 
     eprintln!("touch the key twice to enrol");
-    let (credential, enrolled_key) = fido::enroll([9u8; 32]).expect("enrol");
+    let salt: [u8; 32] = rand::random();
+    let (credential, enrolled_key) = fido::enroll(salt).expect("enrol");
     assert!(!credential.credential_id.is_empty());
 
     eprintln!("touch the key to derive");
@@ -41,7 +42,7 @@ fn enrols_derives_and_detects_the_authenticator() {
 
     let stranger = fido::HardwareCredential {
         credential_id: vec![7u8; 64],
-        salt: [9u8; 32],
+        salt,
     };
     assert!(
         !fido::is_present(&stranger),
@@ -53,7 +54,7 @@ fn enrols_derives_and_detects_the_authenticator() {
     eprintln!("touch the key once more to check salt separation");
     let other_salt = fido::HardwareCredential {
         credential_id: credential.credential_id.clone(),
-        salt: [1u8; 32],
+        salt: rand::random(),
     };
     let derived = fido::derive_dwk(&other_salt).expect("derive with another salt");
     assert_ne!(first, derived);

--- a/crates/zann-keystore/tests/fido_authenticator.rs
+++ b/crates/zann-keystore/tests/fido_authenticator.rs
@@ -1,0 +1,60 @@
+//! Round-trip against a real FIDO2 authenticator.
+//!
+//! Ignored by default: it needs a token that supports `hmac-secret` physically
+//! connected, and it asks for three touches. It also leaves one non-discoverable
+//! credential behind — those consume no storage on the authenticator, so there
+//! is nothing to clean up. Run it manually with:
+//!
+//! ```text
+//! cargo test -p zann-keystore --test fido_authenticator -- --ignored
+//! ```
+
+#![cfg(any(target_os = "linux", target_os = "macos"))]
+
+use zann_keystore::fido;
+
+#[test]
+#[ignore = "requires a connected FIDO2 authenticator and three touches"]
+fn enrols_derives_and_detects_the_authenticator() {
+    fido::authenticator_status().expect("an authenticator must be connected");
+
+    eprintln!("touch the key twice to enrol");
+    let (credential, enrolled_key) = fido::enroll([9u8; 32]).expect("enrol");
+    assert!(!credential.credential_id.is_empty());
+
+    eprintln!("touch the key to derive");
+    let first = fido::derive_dwk(&credential).expect("derive");
+    assert_eq!(
+        first, enrolled_key,
+        "enrolment must hand back the same key a later unlock derives"
+    );
+
+    eprintln!("touch the key to derive again");
+    let second = fido::derive_dwk(&credential).expect("derive again");
+    assert_eq!(first, second, "the DWK must be reproducible");
+
+    // No touch from here on.
+    assert!(
+        fido::is_present(&credential),
+        "the enrolled authenticator is connected, so presence must be detected"
+    );
+
+    let stranger = fido::HardwareCredential {
+        credential_id: vec![7u8; 64],
+        salt: [9u8; 32],
+    };
+    assert!(
+        !fido::is_present(&stranger),
+        "a credential from some other authenticator must not count as present"
+    );
+
+    // A different salt is a different key: this is what lets two vaults share
+    // one authenticator without sharing a wrapping key.
+    eprintln!("touch the key once more to check salt separation");
+    let other_salt = fido::HardwareCredential {
+        credential_id: credential.credential_id.clone(),
+        salt: [1u8; 32],
+    };
+    let derived = fido::derive_dwk(&other_salt).expect("derive with another salt");
+    assert_ne!(first, derived);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,9 @@
             expat
             fontconfig
             freetype
+            # zann-ffi тянет zann-keystore, а тот hidapi для FIDO2-ключей;
+            # его C-часть требует libudev с заголовками.
+            udev
           ] ++ runtimeLibs;
 
           # Иконки лежат у Tauri-приложения: логотип у продукта один.
@@ -140,6 +143,9 @@
             k6
             pkg-config
             openssl
+            # hidapi (через ctap-hid-fido2) собирает C-часть и требует libudev
+            # с заголовками; без него FIDO2-бэкенд кейстора не компилируется.
+            udev
             jemalloc
             llvm
             libxkbcommon
@@ -183,6 +189,7 @@
             rust-bin.stable.latest.default
             pkg-config
             openssl
+            udev
             libxkbcommon
             wayland
             wayland-protocols


### PR DESCRIPTION
## Summary

A FIDO2 hardware key becomes a third way to remember the unlock on a device, next to the OS keystore. It is **optional convenience**: the master password stays the root of trust and always works, and a user without a token sees no change.

The key replaces *typing the master password on a device where it was already entered once*. It is deliberately not a second factor on top of the password, and not part of the master key derivation — both would mean losing every token equals losing the vault, which needs a recovery-code mechanism this project does not have.

Closes #147.

## How it works

```
DWK = blake3::derive_key(context, authenticator.hmac_secret(credential_id, salt))
```

Persisted per device: `credential_id`, `salt` (neither secret) and the master key wrapped with the derived key. Nothing of ours is written to the token, and the master key never reaches it.

- **Non-discoverable credentials, user presence only** — touch, no PIN. Leaves the token's ~25 discoverable slots for other uses. The credential type is a parameter of enrolment, so the portable-unlock idea in #149 can ask for a resident credential later without a redesign.
- **Multiple keys from day one** — one credential and one wrapped copy per token, so a backup key is a peer rather than a fallback. Enrolling the first one offers to add a second in the same flow.
- **Exactly one active source** — with both live the keystore would answer first and the token would be decoration. Switching to a key deletes the keystore's device key.
- **Auto-lock treats an inserted key as presence** in both clients. With a ten-minute timeout, a token otherwise means touching every ten minutes, and the usual reaction to that is switching auto-lock off entirely. Pulling the key is what locks. Presence is a silent assertion against the stored `credential_id` (~170ms, no touch), so it identifies *that* token rather than "some FIDO device is plugged in".

## Structure

The policy — settings shape, wrapping, source selection, enrolment, migration — lives in `zann-keystore` rather than in the desktop app, so both clients share it. This is the direction ADR 0001 already prescribes, and it is what makes the COSMIC support in this PR small.

`zann-ffi` exposes it as seven facade methods, and the master key never crosses that boundary: clients ask for an unlock, they never see or supply key material.

Deviation from the issue text worth flagging: the FIDO backend is not "another implementation of the `Keystore` trait". That trait is store-shaped (`store`/`load`/`delete`) and an authenticator derives rather than stores, so forcing it in would have meant a dishonest interface.

## A bug found on the way

The remembered unlock first went into `config.json`. That file is written by three separate typed structs — `zann-client`, `zann-cli` and the desktop — and serde drops fields none of them model, so **an enrolment made in one client would silently disappear on the next config write by another**. It now lives in its own `unlock.json`, owned by `zann-keystore` and written `0600`, where no other client's struct can reach it. The desktop moved off `desktop.json` for this state and migrates existing files on first load.

## Verified

On a YubiKey 5C NFC (5.8.0), against a scratch vault:

- Enrolment through the COSMIC UI, and the resulting `unlock.json`: source switched, credential and wrapped copy written, `identity` untouched.
- `hardware_key_present` → `true` **without a touch**.
- `unlock_remembered` → vault open, one touch.
- `cargo test -p zann-keystore --test fido_authenticator -- --ignored` — enrol, derive, derive again (same key), presence, salt separation. Ignored by default: it needs a connected token and five touches.

Automated: 14 tests in `zann-keystore`, 13 in the desktop backend (including the `desktop.json` → `unlock.json` migration), 2 in `zann-ffi`, 6 in COSMIC; workspace suite, `cargo fmt --check` and clippy clean on the touched crates.

**Not verified:** the desktop UI end to end, COSMIC auto-lock firing (a ten-minute timeout is impractical to sit through), and macOS — `ctap-hid-fido2` covers it over HID but nobody has run it there.

## Build prerequisite

`hidapi` compiles a C part that needs libudev headers, so `udev` is added to both dev shells and to the `zann-cosmic` package derivation — without the last one `nix build .#zann-cosmic` would break.

## Follow-ups

- #149 — portable unlock via server-side envelopes, still a design discussion.
- Windows: `Unsupported` for now; a non-elevated process cannot reach FIDO devices over raw HID there and needs `webauthn.dll`.
- The COSMIC client still has no way to change the auto-lock timeout; it uses a fixed ten minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
