### PR TITLE
ci(repo): build the COSMIC nix package on packaging changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       docker: ${{ steps.filter.outputs.docker }}
       js: ${{ steps.filter.outputs.js }}
       audit_surface: ${{ steps.filter.outputs.audit_surface }}
+      cosmic: ${{ steps.filter.outputs.cosmic }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
       - name: Checkout
@@ -61,6 +62,14 @@ jobs:
               - 'crates/zann-server/src/domains/access_control/**'
               - 'crates/zann-server/src/infra/audit.rs'
               - 'crates/zann-keystore/**'
+            # Собирать пакет на каждое изменение в crates/** слишком дорого:
+            # libcosmic с wgpu строятся десятки минут. Поэтому фильтр только на
+            # то, что описывает саму упаковку. Плата за это — поломка cosmic
+            # правкой в crates/** всплывёт на следующем PR, который его трогает.
+            cosmic:
+              - 'apps/cosmic/**'
+              - 'flake.nix'
+              - 'flake.lock'
             ci:
               - '.github/workflows/**'
 
@@ -260,6 +269,34 @@ jobs:
         uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Упаковка COSMIC-клиента ломается тихо: ревизия libcosmic, его git-подмодули
+  # и доступность crates.io живут вне нашего кода, а обычные rust-джобы
+  # деривацию не трогают вообще.
+  cosmic-package:
+    needs: changes
+    if: needs.changes.outputs.cosmic == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      # Дёшево и ловит опечатки в выражении и пропавшие атрибуты.
+      - name: Evaluate the flake
+        run: nix flake check --no-build
+      # Сборка libcosmic не влезает в свободное место раннера рядом с
+      # предустановленными образами.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          df -h /
+      - name: Build the package
+        run: nix build .#zann-cosmic --no-link --print-build-logs
 
   licenses:
     needs: changes


### PR DESCRIPTION
## Summary

The COSMIC packaging breaks quietly: the libcosmic revision, its git submodules and crates.io availability all live outside this repository, and the ordinary Rust jobs never touch the derivation. This adds a `cosmic-package` job that builds it.

The path filter is deliberately narrow — `apps/cosmic/**`, `flake.nix`, `flake.lock` — because building the package on every change under `crates/**` is expensive: libcosmic with wgpu takes tens of minutes. The trade is that a break caused by a change in `crates/**` surfaces on the next PR that touches the packaging rather than immediately.

This commit was written before #150 and sat unpushed on a local `main`; `main` is protected, so it comes through a PR like everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)